### PR TITLE
fix two minor bugs in scap-workbench.8 manpage

### DIFF
--- a/man/scap-workbench.8
+++ b/man/scap-workbench.8
@@ -4,7 +4,7 @@
 scap\-workbench \- GUI tool for systems compliance evaluation
 
 .SH SYNOPSIS
-\fBscap-workbench\fR [--skip-valid] [\fIXCCDF_FILE\fR]
+\fBscap\-workbench\fR [\-\-skip\-valid] [\fIXCCDF_FILE\fR]
 
 .SH DESCRIPTION
 SCAP Workbench is GUI tool for security compliance checking. Compliance can be
@@ -18,7 +18,7 @@ This tool enables users to:
 
 .SH OPTIONS
 .TP
-\fB--skip-valid\fR
+\fB\-\-skip\-valid\fR
 If this option is provided openscap validation will not be performed.
 This is recommended only for advanced users and may cause OpenSCAP or SCAP Workbench
 to crash!
@@ -28,7 +28,7 @@ If this parameter is provided the scanner will immediately open given XCCDF or
 source datastream (SDS) file after it starts.
 
 .SH SCAP CONTENT
-Sample content is provided by the OpenSCAP project (in the \fBopenscap-content\fR package).
+Sample content is provided by the OpenSCAP project (in the \fBopenscap\-content\fR package).
 
 Other sources of SCAP content are:
 .TP
@@ -36,9 +36,9 @@ Other sources of SCAP content are:
 .TP
 \fBRed Hat content repository\fR - \fIhttp://www.redhat.com/security/data/oval/\fR
 .TP
-\fBscap-security-guide project\fR - \fIhttp://fedorahosted.org/scap-security-guide/\fR
+\fBscap\-security\-guide project\fR - \fIhttp://fedorahosted.org/scap\-security\-guide/\fR
 .TP
-\fBsce-community-content project\fR - \fIhttp://fedorahosted.org/sce-community-content/\fR
+\fBsce\-community\-content project\fR - \fIhttp://fedorahosted.org/sce\-community\-content/\fR
 
 .SH AUTHORS
 

--- a/man/scap-workbench.8
+++ b/man/scap-workbench.8
@@ -1,7 +1,7 @@
 .TH scap-workbench "8" "Sep 2013" "Red Hat" "System Administration Utilities"
 
 .SH NAME
-SCAP Workbench \- GUI tool for systems compliance evaluation
+scap\-workbench \- GUI tool for systems compliance evaluation
 
 .SH SYNOPSIS
 \fBscap-workbench\fR [--skip-valid] [\fIXCCDF_FILE\fR]


### PR DESCRIPTION
The manpage has some minor bugs:

* Fix manpage title (name), so the whatis command work properly.
* Fix hyphen where a minus sign was intended