### PR TITLE
bash: fix quotes

### DIFF
--- a/scap-workbench-oscap.sh
+++ b/scap-workbench-oscap.sh
@@ -45,15 +45,15 @@ for i in $(seq 0 `expr $# - 1`); do
 
     case "${args[i]}" in
     ("--results")
-        TARGET_RESULTS_XCCDF=${args[j]}
+        TARGET_RESULTS_XCCDF="${args[j]}"
         args[j]="$TEMP_DIR/results-xccdf.xml"
       ;;
     ("--results-arf")
-        TARGET_RESULTS_ARF=${args[j]}
+        TARGET_RESULTS_ARF="${args[j]}"
         args[j]="$TEMP_DIR/results-arf.xml"
       ;;
     ("--report")
-        TARGET_REPORT=${args[j]}
+        TARGET_REPORT="${args[j]}"
         args[j]="$TEMP_DIR/report.html"
       ;;
     *)
@@ -64,7 +64,7 @@ done
 LOCAL_OSCAP="oscap"
 
 pushd "$TEMP_DIR" > /dev/null
-$LOCAL_OSCAP ${args[@]} &
+$LOCAL_OSCAP "${args[@]}" &
 PID=$!
 RET=1
 
@@ -86,8 +86,8 @@ popd > /dev/null
 
 function chown_copy
 {
-    local what=$1
-    local where=$2
+    local what="$1"
+    local where="$2"
 
     [ ! -f "$what" ] || cp "$what" "$where"
 
@@ -97,9 +97,9 @@ function chown_copy
     fi
 }
 
-chown_copy "$TEMP_DIR/results-xccdf.xml" $TARGET_RESULTS_XCCDF
-chown_copy "$TEMP_DIR/results-arf.xml" $TARGET_RESULTS_ARF
-chown_copy "$TEMP_DIR/report.html" $TARGET_REPORT
+chown_copy "$TEMP_DIR/results-xccdf.xml" "$TARGET_RESULTS_XCCDF"
+chown_copy "$TEMP_DIR/results-arf.xml" "$TARGET_RESULTS_ARF"
+chown_copy "$TEMP_DIR/report.html" "$TARGET_REPORT"
 
 rm -r "$TEMP_DIR"
 

--- a/scap-workbench-pkexec-oscap.sh
+++ b/scap-workbench-pkexec-oscap.sh
@@ -29,7 +29,7 @@ SCAP_WORKBENCH_OSCAP="$PARENT_DIR/scap-workbench-oscap.sh"
 # We run unprivileged if pkexec was not found.
 #which $PKEXEC_PATH > /dev/null || exit 1 # fail if pkexec was not found
 
-$PKEXEC_PATH --disable-internal-agent $SCAP_WORKBENCH_OSCAP $uid $gid $@ 2> >(tail -n +2 1>&2)
+$PKEXEC_PATH --disable-internal-agent "$SCAP_WORKBENCH_OSCAP" $uid $gid "$@" 2> >(tail -n +2 1>&2)
 EC=$?
 
 # 126 is a special exit code of pkexec when user dismisses the auth dialog
@@ -38,7 +38,7 @@ EC=$?
 # This is common in niche desktop environments.
 if [ $EC -eq 126 ] || [ $EC -eq 127 ]; then
     # in case of dismissed dialog we run without super user rights
-    $SCAP_WORKBENCH_OSCAP $uid $gid $@ 2> >(tail -n +2 1>&2);
+    "$SCAP_WORKBENCH_OSCAP" $uid $gid "$@" 2> >(tail -n +2 1>&2);
     exit $?
 fi
 


### PR DESCRIPTION
Bash scripts don't contain quotes where necessary - it cause problems with spaces in path, etc..
https://github.com/OpenSCAP/scap-workbench/issues/33