### PR TITLE
bash: fix quotes

### DIFF
--- a/scap-workbench-rpm-extract.sh
+++ b/scap-workbench-rpm-extract.sh
@@ -18,5 +18,5 @@
 
 set -u -o pipefail
 
-rpm2cpio $1 | cpio -ivd
+rpm2cpio "$1" | cpio -ivd
 exit $?


### PR DESCRIPTION
Bash scripts don't contain quotes where necessary - it cause problems with spaces in path, etc..
#33