### PR TITLE
Show LibXML errors in Diagnostics Dialog

### DIFF
--- a/include/DiagnosticsDialog.h
+++ b/include/DiagnosticsDialog.h
@@ -51,6 +51,17 @@ enum MessageSeverity
 };
 
 /**
+ * @brief MessageFormat can be any subset of this flags
+ */
+enum MessageFormat
+{
+    MF_STANDARD = 0x01,
+    MF_PREFORMATTED = 0x02, // Preserve whitespaces to output
+    MF_XML = 0x04, // Replace xml metacharacters with xml entities
+    MF_PREFORMATTED_XML = MF_PREFORMATTED | MF_XML,
+};
+
+/**
  * @brief Workbench displays errors and warnings, this dialog groups them
  *
  * This is a final class and is not supposed to be inherited.
@@ -85,7 +96,7 @@ class DiagnosticsDialog : public QDialog
          * The diagnostics dialog will not open when just these messages are
          * received.
          */
-        void infoMessage(const QString& message);
+        void infoMessage(const QString& message, MessageFormat format = MF_STANDARD);
 
         /**
          * @brief Scanner triggers this to show a warning message
@@ -93,7 +104,7 @@ class DiagnosticsDialog : public QDialog
          * A warning message will open the diagnostics dialog if it isn't
          * being shown already.
          */
-        void warningMessage(const QString& message);
+        void warningMessage(const QString& message, MessageFormat format = MF_STANDARD);
 
         /**
          * @brief Scanner triggers this to show an error message
@@ -101,15 +112,15 @@ class DiagnosticsDialog : public QDialog
          * An error message will open the diagnostics dialog if it isn't
          * being shown already.
          */
-        void errorMessage(const QString& message);
+        void errorMessage(const QString& message, MessageFormat format = MF_STANDARD);
 
         /**
          * @brief Report a caught exception.
          */
-        void exceptionMessage(const std::exception& e, const QString& context = "");
+        void exceptionMessage(const std::exception& e, const QString& context = "", MessageFormat format = MF_STANDARD);
 
     private:
-        void pushMessage(MessageSeverity severity, const QString& fullMessage);
+        void pushMessage(MessageSeverity severity, const QString& fullMessage, MessageFormat format = MF_STANDARD);
 
         /**
          * @brief Pushes a single info message containing version info

--- a/include/LibXmlErrorGuard.h
+++ b/include/LibXmlErrorGuard.h
@@ -39,7 +39,7 @@ public:
     ~LibXmlErrorGuard();
 
     const QString& getMessage() const;
-    bool isEmpty();
+    bool isEmpty() const;
 private:
     static void libxmlErrorCallback(QString* message, const char* format, ...);
     QString errorMessage;

--- a/include/LibXmlErrorGuard.h
+++ b/include/LibXmlErrorGuard.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2013 Red Hat Inc., Durham, North Carolina.
+ * All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef SCAP_WORKBENCH_LIB_XML_ERROR_GUARD_H_
+#define SCAP_WORKBENCH_LIB_XML_ERROR_GUARD_H_
+#include <QString>
+
+/**
+ * @brief Catch LibXML2 errors and store them
+ *
+ */
+class LibXmlErrorGuard
+{
+public:
+    /**
+     * @brief Read LibXML2 errors using xmlSetGenericErrorFunc
+     */
+    LibXmlErrorGuard();
+
+    /**
+     * @brief Reset xmlGenericErrorFunc to default callback
+     */
+    ~LibXmlErrorGuard();
+
+    const QString& getMessage() const;
+    bool isEmpty();
+private:
+    static void libxmlErrorCallback(QString* message, const char* format, ...);
+    QString errorMessage;
+};
+
+#endif // SCAP_WORKBENCH_LIB_XML_ERROR_GUARD_H_

--- a/src/DiagnosticsDialog.cpp
+++ b/src/DiagnosticsDialog.cpp
@@ -63,36 +63,37 @@ void DiagnosticsDialog::waitUntilHidden(unsigned int interval)
     }
 }
 
-void DiagnosticsDialog::infoMessage(const QString& message)
+void DiagnosticsDialog::infoMessage(const QString& message, MessageFormat format)
 {
-    pushMessage(MS_INFO, message);
+    pushMessage(MS_INFO, message, format);
 }
 
-void DiagnosticsDialog::warningMessage(const QString& message)
+void DiagnosticsDialog::warningMessage(const QString& message, MessageFormat format)
 {
-    pushMessage(MS_WARNING, message);
+    pushMessage(MS_WARNING, message, format);
 
     // warning message is important, make sure the diagnostics are shown
     show();
 }
 
-void DiagnosticsDialog::errorMessage(const QString& message)
+void DiagnosticsDialog::errorMessage(const QString& message, MessageFormat format)
 {
-    pushMessage(MS_ERROR, message);
+    pushMessage(MS_ERROR, message, format);
 
     // error message is important, make sure the diagnostics are shown
     show();
 }
 
-void DiagnosticsDialog::exceptionMessage(const std::exception& e, const QString& context)
+void DiagnosticsDialog::exceptionMessage(const std::exception& e, const QString& context, MessageFormat format)
 {
-    pushMessage(MS_EXCEPTION, (context.isEmpty() ? "" : context + "\n\n" + QString::fromUtf8(e.what())));
+    pushMessage(MS_EXCEPTION, (context.isEmpty() ? "" : context + "\n\n" + QString::fromUtf8(e.what())), format);
 
     // error message is important, make sure the diagnostics are shown
     show();
 }
 
-void DiagnosticsDialog::pushMessage(MessageSeverity severity, const QString& fullMessage)
+
+void DiagnosticsDialog::pushMessage(MessageSeverity severity, const QString& fullMessage, MessageFormat format)
 {
     char stime[11];
     stime[10] = '\0';
@@ -132,9 +133,21 @@ void DiagnosticsDialog::pushMessage(MessageSeverity severity, const QString& ful
     strSeverity = strSeverity.leftJustified(8);
 
     std::cerr << stime << " | " << strSeverity.toUtf8().constData() << " | " << fullMessage.toUtf8().constData() << std::endl;
+   
+    QString outputMessage = fullMessage;
+    if (format & MF_XML)
+    {
+        outputMessage = Qt::escape(outputMessage);
+    }
+    
+    if (format & MF_PREFORMATTED)
+    {
+        outputMessage = QString("<pre>%1</pre>").arg(outputMessage);
+    }
+    
     mUI.messages->append(
         QString("<table><tr><td style=\"padding:5px 0px 0px 5px\"><pre>%1 </pre></td><td style=\"background: %2; padding:5px\"><pre>%3 </pre></td><td>%4</td></tr></table>\n")
-            .arg(stime, bgCol, strSeverity, fullMessage)
+            .arg(stime, bgCol, strSeverity, outputMessage)
     );
 }
 

--- a/src/LibXmlErrorGuard.cpp
+++ b/src/LibXmlErrorGuard.cpp
@@ -39,7 +39,7 @@ const QString& LibXmlErrorGuard::getMessage() const
    return errorMessage;
 }
 
-bool LibXmlErrorGuard::isEmpty()
+bool LibXmlErrorGuard::isEmpty() const
 {
     return errorMessage.isEmpty();
 }

--- a/src/LibXmlErrorGuard.cpp
+++ b/src/LibXmlErrorGuard.cpp
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2013 Red Hat Inc., Durham, North Carolina.
+ * All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "LibXmlErrorGuard.h"
+extern "C" {
+    #include <libxml2/libxml/xmlerror.h>
+    #include <stdarg.h>
+}
+
+LibXmlErrorGuard::LibXmlErrorGuard()
+{
+    xmlSetGenericErrorFunc(&errorMessage,(xmlGenericErrorFunc)(&LibXmlErrorGuard::libxmlErrorCallback));
+}
+
+LibXmlErrorGuard::~LibXmlErrorGuard()
+{
+    // set default libxml error handler
+    xmlSetGenericErrorFunc(NULL, (xmlGenericErrorFunc)NULL);
+}
+
+const QString& LibXmlErrorGuard::getMessage() const
+{
+   return errorMessage;
+}
+
+bool LibXmlErrorGuard::isEmpty()
+{
+    return errorMessage.isEmpty();
+}
+
+void LibXmlErrorGuard::libxmlErrorCallback(QString* message, const char* format, ... )
+{
+    try
+    {
+        va_list args;
+        va_start(args, format);
+        QString newMessage = QString().vsprintf(format, args);
+        va_end(args);
+        message->append(newMessage);
+    }
+    catch(...)
+    {
+        ; // Possible exceptions aren't safe in C callback
+    }
+}

--- a/src/LibXmlErrorGuard.cpp
+++ b/src/LibXmlErrorGuard.cpp
@@ -56,6 +56,7 @@ void LibXmlErrorGuard::libxmlErrorCallback(QString* message, const char* format,
     }
     catch(...)
     {
-        ; // Possible exceptions aren't safe in C callback
+        // It's corner case, but some exceptions like std::bad_alloc can occur
+        // Exceptions aren't safe in C callback, so we rather catch them.
     }
 }


### PR DESCRIPTION
Add LibXML errors to diagnostics dialog according to
https://github.com/OpenSCAP/scap-workbench/issues/27