### PR TITLE
Fix strange characters in report after remote scan

### DIFF
--- a/src/ProcessHelpers.cpp
+++ b/src/ProcessHelpers.cpp
@@ -163,8 +163,8 @@ void SyncProcess::run()
 
     mRunning = false;
 
-    mStdOutContents = QString::fromUtf8(process.readAllStandardOutput());
-    mStdErrContents = QString::fromUtf8(process.readAllStandardError());
+    mStdOutContents = QString::fromLocal8Bit(process.readAllStandardOutput());
+    mStdErrContents = QString::fromLocal8Bit(process.readAllStandardError());
 
     // TODO: We are duplicating data here!
     mDiagnosticInfo += "stdout:\n===============================\n" + QString(mStdOutContents) + QString("\n");

--- a/src/ProcessHelpers.cpp
+++ b/src/ProcessHelpers.cpp
@@ -163,8 +163,8 @@ void SyncProcess::run()
 
     mRunning = false;
 
-    mStdOutContents = process.readAllStandardOutput();
-    mStdErrContents = process.readAllStandardError();
+    mStdOutContents = QString::fromUtf8(process.readAllStandardOutput());
+    mStdErrContents = QString::fromUtf8(process.readAllStandardError());
 
     // TODO: We are duplicating data here!
     mDiagnosticInfo += "stdout:\n===============================\n" + QString(mStdOutContents) + QString("\n");


### PR DESCRIPTION
Steps to reproduce:
- select remote scan (Linux->Linux) (you can select your localhost)
- scan
- show report -> You will see 'Â' in front of addresses (and in some other parts of document)

![screenshot_2015-09-01_13-36-58](https://cloud.githubusercontent.com/assets/2564361/9603113/9219e646-50ae-11e5-81f2-6993fc09fe54.png)

@msrubar found this bug