### PR TITLE
Don't allow edit values with changes-prohibited

### DIFF
--- a/src/TailoringDockWidgets.cpp
+++ b/src/TailoringDockWidgets.cpp
@@ -212,17 +212,28 @@ void XCCDFItemPropertiesDockWidget::refresh()
                     break;
             }
 
-            struct xccdf_value_instance_iterator* it = xccdf_value_get_instances(value);
-            while (xccdf_value_instance_iterator_has_more(it))
+            bool prohibitChanges = xccdf_value_get_prohibit_changes(value);
+            mUI.valueGroupBox->setDisabled(prohibitChanges);
+
+            if (prohibitChanges)
             {
-                struct xccdf_value_instance* instance = xccdf_value_instance_iterator_next(it);
-                mUI.valueComboBox->addItem(QString::fromUtf8(xccdf_value_instance_get_value(instance)));
+                mUI.valueComboBox->setEditText("(changes prohibited)");
             }
-            xccdf_value_instance_iterator_free(it);
+            else
+            {
+                struct xccdf_value_instance_iterator* it = xccdf_value_get_instances(value);
+                while (xccdf_value_instance_iterator_has_more(it))
+                {
+                    struct xccdf_value_instance* instance = xccdf_value_instance_iterator_next(it);
+                    mUI.valueComboBox->addItem(QString::fromUtf8(xccdf_value_instance_get_value(instance)));
+                }
+                xccdf_value_instance_iterator_free(it);
 
-            mUI.valueComboBox->setEditText(mWindow->getCurrentValueValue(value));
+                mUI.valueComboBox->setEditText(mWindow->getCurrentValueValue(value));
 
-            mUI.valueComboBox->insertSeparator(1);
+                mUI.valueComboBox->insertSeparator(1);
+            }
+
             mUI.valueGroupBox->show();
 
             {


### PR DESCRIPTION
https://github.com/OpenSCAP/scap-workbench/issues/67
According to SSG, it use `prohibitChanges` instead of `interactive`
```
<Value id="xccdf_org.ssgproject.content_value_function_fix_audit_syscall_rule" hidden="true" prohibitChanges="true" operator="equals" type="string">
```
Do you have better idea how to visually show "changes prohibited"? (otherwise it should be ready to merge)
![screenshot_2016-08-24_14-45-19](https://cloud.githubusercontent.com/assets/2564361/17931018/914d5a3e-6a09-11e6-8743-fef42af27d15.png)
