### PR TITLE
RHBZ#1368527 Add support for --version and --help

### DIFF
--- a/include/Application.h
+++ b/include/Application.h
@@ -60,6 +60,21 @@ class Application : public QApplication
          */
         void browseForContent();
 
+        /**
+         * @brief Prints version of SCAP Workbench
+         */
+        void printVersion();
+
+        /**
+         * @brief Prints help of SCAP Workbench
+         */
+        void printHelp();
+
+        /**
+         * @brief Whether the application should quit
+         */
+        bool shouldQuit;
+
         bool mSkipValid;
         /// Needed for QObject::tr(..) to work properly, loaded on app startup
         QTranslator mTranslator;

--- a/include/MainWindow.h
+++ b/include/MainWindow.h
@@ -86,6 +86,14 @@ class MainWindow : public QMainWindow
         void openFileDialogAsync();
 
         /**
+         * @brief Queues the MainWindow to be closed later when in the event loop
+         *
+         * This avoids the window closing before the event loop is entered.
+         * @see MainWindow::closeMainWindow
+         */
+        void closeMainWindowAsync();
+
+        /**
          * @brief Checks whether a file is currently opened
          */
         bool fileOpened() const;
@@ -234,6 +242,14 @@ class MainWindow : public QMainWindow
          * before it even starts.
          */
         void showOpenFileDialog();
+
+        /**
+         * @brief We signal this to close the MainWindow
+         *
+         * This is to make sure we close the MainWindow during the event loop, not
+         * before it even starts.
+         */
+        void closeMainWindow();
 
         /**
          * @brief This is signaled when scanning is canceled

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -90,6 +90,14 @@ MainWindow::MainWindow(QWidget* parent):
     mUI.remoteMachineDetails->hide();
 
     QObject::connect(
+        this, SIGNAL(closeMainWindow()),
+        this, SLOT(close()),
+        // Queued to prevent closing the MainWindow before event loop is
+        // entered. Without this the application wouldn't quit gracefully.
+        Qt::QueuedConnection
+    );
+
+    QObject::connect(
         this, SIGNAL(showOpenFileDialog()),
         this, SLOT(openFileDialog()),
         // Queued to prevent opening a blocking dialog before event loop is
@@ -439,6 +447,11 @@ void MainWindow::openSSGDialog(const QString& customDismissLabel)
     }
 
     delete dialog;
+}
+
+void MainWindow::closeMainWindowAsync()
+{
+    emit closeMainWindow();
 }
 
 void MainWindow::openFileDialogAsync()


### PR DESCRIPTION
Arguments -v and --version prints the version of SCAP Workbench,
and arguments -h and --help prints the usage of SCAP Workbench.

This is the same funcionality added  by
commit 9d821197d5c13e058dbdc5b8a6a03839e5817e6a, but not
using QCommandLineParser, which is only available in Qt5.