### PR TITLE
Fix tailoring file path of dry run

### DIFF
--- a/include/OscapScannerBase.h
+++ b/include/OscapScannerBase.h
@@ -48,7 +48,7 @@ class OscapScannerBase : public Scanner
         virtual void signalCompletion(bool canceled);
 
         bool checkPrerequisites();
-
+        QString surroundQuote(const QString& input)const;
         QStringList buildEvaluationArgs(const QString& inputFile,
                                         const QString& tailoringFile,
                                         const QString& resultFile,

--- a/include/ScanningSession.h
+++ b/include/ScanningSession.h
@@ -163,6 +163,11 @@ class ScanningSession
         QString getTailoringFilePath();
 
         /**
+         * @brief Returns the path of the original tailoring file provided by user
+         */
+        QString getUserTailoringFilePath();
+
+        /**
          * @brief Generates guide and saves it to supplied path
          */
         void generateGuide(const QString& path);

--- a/include/ScanningSession.h
+++ b/include/ScanningSession.h
@@ -149,8 +149,13 @@ class ScanningSession
 
         /**
          * @brief Saves tailoring to given file path
+         *
+         * @param userFile if true, the path will be kept as a user provided
+         * path for the current tailoring file
+         *
+         * @see getUserTailoringFilePath
          */
-        void saveTailoring(const QString& path);
+        void saveTailoring(const QString& path, bool userFile);
 
         /**
          * @brief Exports tailoring file to a temporary path and returns the path
@@ -163,7 +168,7 @@ class ScanningSession
         QString getTailoringFilePath();
 
         /**
-         * @brief Returns the path of the original tailoring file provided by user
+         * @brief Returns the path of the tailoring file loaded or saved by user
          */
         QString getUserTailoringFilePath();
 

--- a/include/ScanningSession.h
+++ b/include/ScanningSession.h
@@ -168,7 +168,13 @@ class ScanningSession
         QString getTailoringFilePath();
 
         /**
-         * @brief Returns the path of the tailoring file loaded or saved by user
+         * @brief Returns the path of tailoring file most suitable for user presentation
+         *
+         * @par
+         * This method returns the most friendly path for the user.
+         * If a tailoring file has been loaded or saved by user, its path will be returned.
+         * If a profile has been tailored but not saved yet, a temporary path is returned.
+         * If there is no tailoring, an empty string is returned.
          */
         QString getUserTailoringFilePath();
 

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -1269,7 +1269,7 @@ void MainWindow::saveTailoring()
 
     try
     {
-        mScanningSession->saveTailoring(path);
+        mScanningSession->saveTailoring(path, true);
         markUnsavedTailoringChanges();
         markLoadedTailoringFile(path);
     }

--- a/src/OscapScannerBase.cpp
+++ b/src/OscapScannerBase.cpp
@@ -152,6 +152,14 @@ bool OscapScannerBase::checkPrerequisites()
     return true;
 }
 
+QString OscapScannerBase::surroundQuote(const QString& input) const
+{
+    if (input.contains(" "))
+        return QString("\""+input+"\"");
+
+    return input;
+}
+
 QStringList OscapScannerBase::buildEvaluationArgs(const QString& inputFile,
         const QString& tailoringFile,
         const QString& resultFile,
@@ -195,7 +203,10 @@ QStringList OscapScannerBase::buildEvaluationArgs(const QString& inputFile,
     if (!tailoringFile.isEmpty())
     {
         ret.append("--tailoring-file");
-        ret.append(tailoringFile);
+        if (mDryRun)
+            ret.append(surroundQuote(tailoringFile));
+        else
+            ret.append(tailoringFile);
     }
 
     const QString profileId = mSession->getProfile();
@@ -212,13 +223,22 @@ QStringList OscapScannerBase::buildEvaluationArgs(const QString& inputFile,
     ret.append("--oval-results");
 
     ret.append("--results");
-    ret.append(resultFile);
+    if (mDryRun)
+        ret.append(surroundQuote(resultFile));
+    else
+        ret.append(resultFile);
 
     ret.append("--results-arf");
-    ret.append(arfFile);
+    if (mDryRun)
+        ret.append(surroundQuote(arfFile));
+    else
+        ret.append(arfFile);
 
     ret.append("--report");
-    ret.append(reportFile);
+    if (mDryRun)
+        ret.append(surroundQuote(reportFile));
+    else
+        ret.append(reportFile);
 
     if (ignoreCapabilities || mCapabilities.progressReporting())
         ret.append("--progress");
@@ -226,7 +246,10 @@ QStringList OscapScannerBase::buildEvaluationArgs(const QString& inputFile,
     if (onlineRemediation && (ignoreCapabilities || mCapabilities.onlineRemediation()))
         ret.append("--remediate");
 
-    ret.append(inputFile);
+    if (mDryRun)
+        ret.append(surroundQuote(inputFile));
+    else
+        ret.append(inputFile);
 
     return ret;
 }

--- a/src/OscapScannerLocal.cpp
+++ b/src/OscapScannerLocal.cpp
@@ -62,8 +62,9 @@ QStringList OscapScannerLocal::getCommandLineArgs() const
     }
     else
     {
+        QString userTailoringFile = mSession->getUserTailoringFilePath();
         args += buildEvaluationArgs(mSession->getOpenedFilePath(),
-            mSession->hasTailoring() ? mSession->getTailoringFilePath() : QString(),
+            mSession->hasTailoring() ?  ( userTailoringFile.isEmpty() ? mSession->getTailoringFilePath() : userTailoringFile ): QString(),
             "/tmp/xccdf-results.xml",
             "/tmp/report.html",
             "/tmp/arf.xml",

--- a/src/OscapScannerLocal.cpp
+++ b/src/OscapScannerLocal.cpp
@@ -62,9 +62,8 @@ QStringList OscapScannerLocal::getCommandLineArgs() const
     }
     else
     {
-        QString userTailoringFile = mSession->getUserTailoringFilePath();
         args += buildEvaluationArgs(mSession->getOpenedFilePath(),
-            mSession->hasTailoring() ?  ( userTailoringFile.isEmpty() ? mSession->getTailoringFilePath() : userTailoringFile ): QString(),
+            mSession->getUserTailoringFilePath(),
             "/tmp/xccdf-results.xml",
             "/tmp/report.html",
             "/tmp/arf.xml",

--- a/src/OscapScannerRemoteSsh.cpp
+++ b/src/OscapScannerRemoteSsh.cpp
@@ -121,9 +121,8 @@ QStringList OscapScannerRemoteSsh::getCommandLineArgs() const
     }
     else
     {
-        QString userTailoringFile = mSession->getUserTailoringFilePath();
         args += buildEvaluationArgs(mSession->getOpenedFilePath(),
-            mSession->hasTailoring() ?  ( userTailoringFile.isEmpty() ? mSession->getTailoringFilePath() : userTailoringFile ): QString(),
+            mSession->getUserTailoringFilePath(),
             "/tmp/xccdf-results.xml",
             "/tmp/report.html",
             "/tmp/arf.xml",

--- a/src/OscapScannerRemoteSsh.cpp
+++ b/src/OscapScannerRemoteSsh.cpp
@@ -121,8 +121,9 @@ QStringList OscapScannerRemoteSsh::getCommandLineArgs() const
     }
     else
     {
+        QString userTailoringFile = mSession->getUserTailoringFilePath();
         args += buildEvaluationArgs(mSession->getOpenedFilePath(),
-            mSession->hasTailoring() ? mSession->getTailoringFilePath() : QString(),
+            mSession->hasTailoring() ?  ( userTailoringFile.isEmpty() ? mSession->getTailoringFilePath() : userTailoringFile ): QString(),
             "/tmp/xccdf-results.xml",
             "/tmp/report.html",
             "/tmp/arf.xml",

--- a/src/ScanningSession.cpp
+++ b/src/ScanningSession.cpp
@@ -449,7 +449,13 @@ QString ScanningSession::getTailoringFilePath()
 
 QString ScanningSession::getUserTailoringFilePath()
 {
-    return mUserTailoringFile;
+    if (hasTailoring())
+    {
+        if (!mUserTailoringFile.isEmpty())
+            return mUserTailoringFile;
+        return getTailoringFilePath();
+    }
+    return QString();
 }
 
 void ScanningSession::generateGuide(const QString& path)

--- a/src/ScanningSession.cpp
+++ b/src/ScanningSession.cpp
@@ -403,7 +403,7 @@ void ScanningSession::setTailoringComponentID(const QString& componentID)
     mTailoringUserChanges = false;
 }
 
-void ScanningSession::saveTailoring(const QString& path)
+void ScanningSession::saveTailoring(const QString& path, bool userFile)
 {
     ensureTailoringExists();
 
@@ -428,7 +428,9 @@ void ScanningSession::saveTailoring(const QString& path)
         );
     }
 
-    mUserTailoringFile = path;
+    // Keep path if it's a user provided path
+    if (userFile)
+        mUserTailoringFile = path;
 }
 
 QString ScanningSession::getTailoringFilePath()
@@ -440,7 +442,7 @@ QString ScanningSession::getTailoringFilePath()
     mTailoringFile.close();
 
     const QString fileName = mTailoringFile.fileName();
-    saveTailoring(fileName);
+    saveTailoring(fileName, false);
 
     return fileName;
 }

--- a/src/ScanningSession.cpp
+++ b/src/ScanningSession.cpp
@@ -368,11 +368,11 @@ void ScanningSession::setTailoringFile(const QString& tailoringFile)
     if (!fileOpened())
         return;
 
-    mTailoring = 0;
-
     // nothing to change if these conditions are met
     if (!mTailoringUserChanges && mUserTailoringCID.isEmpty() && mUserTailoringFile == tailoringFile)
         return;
+
+    mTailoring = 0;
 
     xccdf_session_set_user_tailoring_cid(mSession, 0);
     mUserTailoringCID = "";
@@ -388,11 +388,11 @@ void ScanningSession::setTailoringComponentID(const QString& componentID)
     if (!fileOpened())
         return;
 
-    mTailoring = 0;
-
     // nothing to change if these conditions are met
     if (!mTailoringUserChanges && mUserTailoringCID == componentID && mUserTailoringFile.isEmpty())
         return;
+
+    mTailoring = 0;
 
     xccdf_session_set_user_tailoring_file(mSession, 0);
     mUserTailoringFile = "";

--- a/src/ScanningSession.cpp
+++ b/src/ScanningSession.cpp
@@ -443,6 +443,11 @@ QString ScanningSession::getTailoringFilePath()
     return fileName;
 }
 
+QString ScanningSession::getUserTailoringFilePath()
+{
+    return mUserTailoringFile;
+}
+
 void ScanningSession::generateGuide(const QString& path)
 {
     // TODO: This does not deal with multiple datastreams inside one file!

--- a/src/ScanningSession.cpp
+++ b/src/ScanningSession.cpp
@@ -427,6 +427,8 @@ void ScanningSession::saveTailoring(const QString& path)
             QString("Exporting customization to '%1' failed! Details follow:\n%2").arg(path).arg(oscapErrDesc())
         );
     }
+
+    mUserTailoringFile = path;
 }
 
 QString ScanningSession::getTailoringFilePath()


### PR DESCRIPTION
RHBZ#1368516

Provide actual file path of tailoring file when using dry run feature.
If tailoring is not saved, a temporary tailoring path is provided.

Also, provide paths with white spaces protected by double quotes.