### PR TITLE
V1-1 fetch remote resources warning

### DIFF
--- a/include/OscapScannerBase.h
+++ b/include/OscapScannerBase.h
@@ -95,6 +95,11 @@ class OscapScannerBase : public Scanner
         void readStdOut(QProcess& process);
         void watchStdErr(QProcess& process);
 
+        /**
+         * @brief Converts OpenSCAP CLI messages to SCAP Workbench GUI messages.
+         */
+        QString guiFriendlyMessage(const QString& cliMessage);
+
         bool mCancelRequested;
 
         OscapCapabilities mCapabilities;

--- a/src/OscapScannerBase.cpp
+++ b/src/OscapScannerBase.cpp
@@ -396,17 +396,27 @@ void OscapScannerBase::watchStdErr(QProcess& process)
 {
     process.setReadChannel(QProcess::StandardError);
 
-    QString errorMessage("");
+    QString stdErrOutput("");
 
+    // As readStdOut() is greedy and will continue reading for as long as there is output for it,
+    // by the time we come to handle sdterr output there may be multiple warning and/or error messages.
     while (process.canReadLine())
     {
         // Trailing \n is returned by QProcess::readLine
-        errorMessage += process.readLine();
-    }
+        stdErrOutput = process.readLine();
 
-    if (!errorMessage.isEmpty())
-    {
-        emit warningMessage(QObject::tr("The 'oscap' process has written the following content to stderr:\n"
-                                        "%1").arg(errorMessage));
+        if (!stdErrOutput.isEmpty())
+        {
+            if (stdErrOutput.contains("WARNING: "))
+            {
+                emit warningMessage(QObject::tr("%1").arg(stdErrOutput.remove("WARNING: ")));
+            }
+            else
+            {
+                emit errorMessage(QObject::tr("The 'oscap' process has written the following content to stderr:\n"
+                                            "%1").arg(stdErrOutput));
+            }
+        }
+
     }
 }

--- a/src/OscapScannerBase.cpp
+++ b/src/OscapScannerBase.cpp
@@ -409,7 +409,8 @@ void OscapScannerBase::watchStdErr(QProcess& process)
         {
             if (stdErrOutput.contains("WARNING: "))
             {
-                emit warningMessage(QObject::tr("%1").arg(stdErrOutput.remove("WARNING: ")));
+                QString guiMessage = guiFriendlyMessage(stdErrOutput.remove("WARNING: "));
+                emit warningMessage(QObject::tr(guiMessage.toUtf8().constData()));
             }
             else
             {
@@ -419,4 +420,14 @@ void OscapScannerBase::watchStdErr(QProcess& process)
         }
 
     }
+
+}
+
+QString OscapScannerBase::guiFriendlyMessage(const QString& cliMessage)
+{
+    QString guiMessage = cliMessage;
+
+    if (cliMessage.contains("--fetch-remote-resource"))
+        guiMessage = QString("Remote resources might be necessary for this profile to work properly. Please select \"Fetch remote resources\" for complete scan.\n");
+    return guiMessage;
 }

--- a/src/OscapScannerBase.cpp
+++ b/src/OscapScannerBase.cpp
@@ -409,7 +409,7 @@ void OscapScannerBase::watchStdErr(QProcess& process)
         {
             if (stdErrOutput.contains("WARNING: "))
             {
-                QString guiMessage = guiFriendlyMessage(stdErrOutput.remove("WARNING: "));
+                QString guiMessage = guiFriendlyMessage(stdErrOutput);
                 emit warningMessage(QObject::tr(guiMessage.toUtf8().constData()));
             }
             else
@@ -427,7 +427,10 @@ QString OscapScannerBase::guiFriendlyMessage(const QString& cliMessage)
 {
     QString guiMessage = cliMessage;
 
+    // Remove "WARNING:" prefix and trailing \n
+    guiMessage.remove(QRegExp("(WARNING: )|\n"));
+
     if (cliMessage.contains("--fetch-remote-resource"))
-        guiMessage = QString("Remote resources might be necessary for this profile to work properly. Please select \"Fetch remote resources\" for complete scan.\n");
+        guiMessage = QString("Remote resources might be necessary for this profile to work properly. Please select \"Fetch remote resources\" for complete scan");
     return guiMessage;
 }


### PR DESCRIPTION
Fix handling of multiple warning/error messages.
And replace messages received from oscap for meaningful messages to scap-workbench user.

Relies on https://github.com/OpenSCAP/openscap/pull/540
RHBZ#1367923