### PR TITLE
Improve MainWindow UX

### DIFF
--- a/include/MainWindow.h
+++ b/include/MainWindow.h
@@ -404,6 +404,21 @@ class MainWindow : public QMainWindow
          * Just a delegate that calls QMessageBox::aboutQt(..)
          */
         void aboutQt();
+
+        /**
+         * @brief Toggles all rule results description state
+         *
+         * Toogles exhibition of description of all rules between collapsed/expanded
+         */
+        void toggleRuleResultsExpanded();
+        void toggleRuleResultsExpanded(bool checked);
+
+
+    private:
+        void setRuleResultsExpanded(bool checked);
+        void setActionToggleRuleResultsText(bool checked);
+
+        bool mRuleResultsExpanded;
 };
 
 #endif

--- a/include/MainWindow.h
+++ b/include/MainWindow.h
@@ -413,6 +413,17 @@ class MainWindow : public QMainWindow
         void toggleRuleResultsExpanded();
         void toggleRuleResultsExpanded(bool checked);
 
+    public slots:
+        /**
+         * @brief Changes state of Expand all/Collapse all button according to boolean received
+         *
+         * @param checked If true, sets actionToggleRuleResults push button to "Collapse all",
+         * if false, sets actionToggleRuleResults to "Expand all"
+         *
+         * @note This function does not toggles the RuleResults, just updates state of MainWindow
+         * according to current RuleResults state
+         */
+        void allRuleResultsExpanded(bool checked);
 
     private:
         void setRuleResultsExpanded(bool checked);

--- a/include/RuleResultItem.h
+++ b/include/RuleResultItem.h
@@ -38,6 +38,11 @@ class RuleResultItem : public QWidget
 
         void setRuleResultChecked(bool checked);
 
+        bool isChecked();
+
+    signals:
+        void ruleResultDescriptionToggled(bool checked);
+
     private slots:
         void showDescriptionToggled(bool checked);
 

--- a/include/RuleResultItem.h
+++ b/include/RuleResultItem.h
@@ -36,6 +36,8 @@ class RuleResultItem : public QWidget
         void setRuleResult(const QString& result);
         bool hasRuleResult() const;
 
+        void setRuleResultChecked(bool checked);
+
     private slots:
         void showDescriptionToggled(bool checked);
 

--- a/include/RuleResultsTree.h
+++ b/include/RuleResultsTree.h
@@ -90,6 +90,11 @@ class RuleResultsTree : public QWidget
          */
         void prepareForScanning();
 
+        /**
+         * @brief Toggles expanded/collapsed state of RuleResults
+         */
+        void toggleAllRuleResultDescription(bool checked);
+
     private:
         void clearAllItems();
 

--- a/include/RuleResultsTree.h
+++ b/include/RuleResultsTree.h
@@ -95,6 +95,24 @@ class RuleResultsTree : public QWidget
          */
         void toggleAllRuleResultDescription(bool checked);
 
+    public slots:
+        /**
+         * @brief Checks if all RuleResults are expanded or collapsed
+         *
+         * If all RuleResults are expanded or collapsed allRuleResultsExpanded signal
+         * is emitted.
+         */
+        void checkRuleResultsExpanded(bool lastAction);
+
+    signals:
+        /**
+         * @brief This is signaled when all RuleResults are either expanded or collapsed
+         *
+         * We signal this when a RuleResult has been expanded or collapse by user click
+         * and as a result all RuleResults are now expanded or collapsed.
+         */
+        void allRuleResultsExpanded(bool checked);
+
     private:
         void clearAllItems();
 

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -1086,6 +1086,12 @@ void MainWindow::setRuleResultsExpanded(bool checked)
 
 }
 
+void MainWindow::allRuleResultsExpanded(bool checked)
+{
+    mRuleResultsExpanded = checked;
+    setActionToggleRuleResultsText(checked);
+}
+
 void MainWindow::setActionToggleRuleResultsText(bool checked)
 {
     if(checked)

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -51,10 +51,10 @@ extern "C" {
 
 // A dialog to open a tailoring file is displayed after user selects this option
 // from the tailoring combobox.
-const QString TAILORING_CUSTOM_FILE = QObject::tr("(open customization file...)");
+const QString TAILORING_CUSTOM_FILE = QObject::tr("Select customization file...");
 // This option signifies that there is no tailoring being done and the plain
 // content file is used, it also resets tailoring when selected.
-const QString TAILORING_NONE = QObject::tr("(no customization)");
+const QString TAILORING_NONE = QObject::tr("None selected");
 // Signifies that tailoring changes have been made and have not been saved
 // to a file (yet?). Selecting it does nothing.
 const QString TAILORING_UNSAVED = QObject::tr("(unsaved changes)");
@@ -81,13 +81,20 @@ MainWindow::MainWindow(QWidget* parent):
     mOldTailoringComboBoxIdx(0),
     mLoadedTailoringFileUserData(TAILORING_NO_LOADED_FILE_DATA),
 
-    mIgnoreProfileComboBox(false)
+    mIgnoreProfileComboBox(false),
+
+    mRuleResultsExpanded(false)
 {
     mUI.setupUi(this);
     mUI.progressBar->reset();
 
     // we start with localhost which doesn't need remote machine details
     mUI.remoteMachineDetails->hide();
+
+    QObject::connect(
+        mUI.expandRulesButton, SIGNAL(clicked()),
+        this, SLOT(toggleRuleResultsExpanded())
+    );
 
     QObject::connect(
         this, SIGNAL(closeMainWindow()),
@@ -746,6 +753,7 @@ void MainWindow::reloadSession()
 
     mUI.resultViewer->clear();
     mUI.titleLabel->setText(mScanningSession->getBenchmarkTitle());
+    toggleRuleResultsExpanded(false);
     refreshProfiles();
 }
 
@@ -1055,6 +1063,35 @@ void MainWindow::profileComboboxChanged(int index)
 
     mUI.ruleResultsTree->refreshSelectedRules(mScanningSession);
     clearResults();
+}
+
+void MainWindow::toggleRuleResultsExpanded()
+{
+    mRuleResultsExpanded = !mRuleResultsExpanded;
+
+    setRuleResultsExpanded(mRuleResultsExpanded);
+}
+
+void MainWindow::toggleRuleResultsExpanded(bool checked)
+{
+    mRuleResultsExpanded = checked;
+
+    setRuleResultsExpanded(mRuleResultsExpanded);
+}
+
+void MainWindow::setRuleResultsExpanded(bool checked)
+{
+    mUI.ruleResultsTree->toggleAllRuleResultDescription(checked);
+    setActionToggleRuleResultsText(checked);
+
+}
+
+void MainWindow::setActionToggleRuleResultsText(bool checked)
+{
+    if(checked)
+        mUI.expandRulesButton->setText(QString("Collapse all"));
+    else
+        mUI.expandRulesButton->setText(QString("Expand all"));
 }
 
 void MainWindow::scanProgressReport(const QString& rule_id, const QString& result)

--- a/src/RuleResultItem.cpp
+++ b/src/RuleResultItem.cpp
@@ -157,3 +157,16 @@ void RuleResultItem::showDescriptionToggled(bool checked)
 
     setUpdatesEnabled(true);
 }
+
+void RuleResultItem::setRuleResultChecked(bool checked)
+{
+    setUpdatesEnabled(false);
+
+    mUi.showDescriptionCheckBox->setChecked(checked);
+
+    if (checked && mUi.description->text().isEmpty())
+        mUi.description->setText(mDescriptionHTML);
+    mUi.description->setVisible(checked);
+
+    setUpdatesEnabled(true);
+}

--- a/src/RuleResultItem.cpp
+++ b/src/RuleResultItem.cpp
@@ -156,6 +156,8 @@ void RuleResultItem::showDescriptionToggled(bool checked)
     mUi.description->setVisible(checked);
 
     setUpdatesEnabled(true);
+
+    emit ruleResultDescriptionToggled(checked);
 }
 
 void RuleResultItem::setRuleResultChecked(bool checked)
@@ -169,4 +171,9 @@ void RuleResultItem::setRuleResultChecked(bool checked)
     mUi.description->setVisible(checked);
 
     setUpdatesEnabled(true);
+}
+
+bool RuleResultItem::isChecked()
+{
+    return mUi.showDescriptionCheckBox->isChecked();
 }

--- a/src/RuleResultsTree.cpp
+++ b/src/RuleResultsTree.cpp
@@ -113,6 +113,11 @@ void RuleResultsTree::refreshSelectedRules(ScanningSession* scanningSession)
 
         RuleResultItem* item = new RuleResultItem(rule, policy, mUI.scrollArea);
 
+        QObject::connect(
+            item, SIGNAL(ruleResultDescriptionToggled(bool)),
+            this, SLOT(checkRuleResultsExpanded(bool))
+        );
+
         const QString ruleID = QString::fromUtf8(xccdf_rule_get_id(rule));
         mRuleIdToWidgetItemMap[ruleID] = item;
 
@@ -188,6 +193,30 @@ void RuleResultsTree::toggleAllRuleResultDescription(bool checked)
     }
 
     mUI.scrollArea->setUpdatesEnabled(true);
+}
+
+void RuleResultsTree::checkRuleResultsExpanded(bool lastAction)
+{
+    RuleResultItem* item;
+
+    mUI.scrollArea->setUpdatesEnabled(false);
+
+    RuleIdToWidgetItemMap::iterator it = mRuleIdToWidgetItemMap.begin();
+    while (it != mRuleIdToWidgetItemMap.end())
+    {
+        item = it->second;
+        if (lastAction == item->isChecked())
+            ++it;
+        else
+        {
+            mUI.scrollArea->setUpdatesEnabled(true);
+            return;
+        }
+    }
+    emit allRuleResultsExpanded(lastAction);
+
+    mUI.scrollArea->setUpdatesEnabled(true);
+
 }
 
 void RuleResultsTree::clearAllItems()

--- a/src/RuleResultsTree.cpp
+++ b/src/RuleResultsTree.cpp
@@ -176,6 +176,20 @@ void RuleResultsTree::injectRuleResult(const QString& ruleID, const QString& res
 void RuleResultsTree::prepareForScanning()
 {}
 
+void RuleResultsTree::toggleAllRuleResultDescription(bool checked)
+{
+    mUI.scrollArea->setUpdatesEnabled(false);
+
+    for (RuleIdToWidgetItemMap::iterator it = mRuleIdToWidgetItemMap.begin();
+         it != mRuleIdToWidgetItemMap.end(); ++it)
+    {
+        RuleResultItem* item = it->second;
+        item->setRuleResultChecked(checked);
+    }
+
+    mUI.scrollArea->setUpdatesEnabled(true);
+}
+
 void RuleResultsTree::clearAllItems()
 {
     for (RuleIdToWidgetItemMap::const_iterator it = mRuleIdToWidgetItemMap.begin();

--- a/ui/MainWindow.ui
+++ b/ui/MainWindow.ui
@@ -10,7 +10,7 @@
     <x>0</x>
     <y>0</y>
     <width>800</width>
-    <height>650</height>
+    <height>850</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -100,6 +100,12 @@
        </item>
        <item row="6" column="0">
         <widget class="QLabel" name="label_3">
+         <property name="font">
+          <font>
+           <weight>75</weight>
+           <bold>true</bold>
+          </font>
+         </property>
          <property name="text">
           <string>Profile</string>
          </property>
@@ -107,6 +113,12 @@
        </item>
        <item row="2" column="0">
         <widget class="QLabel" name="checklistLabel">
+         <property name="font">
+          <font>
+           <weight>75</weight>
+           <bold>true</bold>
+          </font>
+         </property>
          <property name="text">
           <string>Checklist</string>
          </property>
@@ -114,6 +126,12 @@
        </item>
        <item row="8" column="0">
         <widget class="QLabel" name="label">
+         <property name="font">
+          <font>
+           <weight>75</weight>
+           <bold>true</bold>
+          </font>
+         </property>
          <property name="text">
           <string>Target</string>
          </property>
@@ -124,6 +142,12 @@
        </item>
        <item row="5" column="0">
         <widget class="QLabel" name="label_4">
+         <property name="font">
+          <font>
+           <weight>75</weight>
+           <bold>true</bold>
+          </font>
+         </property>
          <property name="text">
           <string>Customization</string>
          </property>
@@ -164,6 +188,12 @@
        </item>
        <item row="3" column="0">
         <widget class="QLabel" name="label_5">
+         <property name="font">
+          <font>
+           <weight>75</weight>
+           <bold>true</bold>
+          </font>
+         </property>
          <property name="text">
           <string>Title</string>
          </property>
@@ -193,27 +223,74 @@
      </widget>
     </item>
     <item>
-     <widget class="RuleResultsTree" name="ruleResultsTree" native="true">
-      <property name="sizePolicy">
-       <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
-        <horstretch>0</horstretch>
-        <verstretch>0</verstretch>
-       </sizepolicy>
+     <layout class="QVBoxLayout" name="ruleResults">
+      <property name="leftMargin">
+       <number>9</number>
       </property>
-     </widget>
-    </item>
-    <item>
-     <widget class="QProgressBar" name="progressBar">
-      <property name="maximum">
-       <number>1</number>
+      <property name="rightMargin">
+       <number>9</number>
       </property>
-      <property name="value">
-       <number>0</number>
-      </property>
-      <property name="format">
-       <string>%p% (%v results, %m rules selected)</string>
-      </property>
-     </widget>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_6">
+        <item>
+         <widget class="QLabel" name="label_2">
+          <property name="font">
+           <font>
+            <weight>75</weight>
+            <bold>true</bold>
+           </font>
+          </property>
+          <property name="text">
+           <string>Rules</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_5">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QPushButton" name="expandRulesButton">
+          <property name="text">
+           <string>Expand All</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <widget class="RuleResultsTree" name="ruleResultsTree" native="true">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QProgressBar" name="progressBar">
+        <property name="maximum">
+         <number>1</number>
+        </property>
+        <property name="value">
+         <number>0</number>
+        </property>
+        <property name="format">
+         <string>%p% (%v results, %m rules selected)</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </item>
     <item>
      <widget class="QWidget" name="widget" native="true">
@@ -305,7 +382,7 @@
               <widget class="QPushButton" name="scanButton">
                <property name="font">
                 <font>
-                 <pointsize>13</pointsize>
+                 <pointsize>18</pointsize>
                  <weight>75</weight>
                  <bold>true</bold>
                 </font>
@@ -439,7 +516,7 @@
      <x>0</x>
      <y>0</y>
      <width>800</width>
-     <height>30</height>
+     <height>27</height>
     </rect>
    </property>
    <property name="font">
@@ -598,6 +675,22 @@
     <hint type="destinationlabel">
      <x>399</x>
      <y>324</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>ruleResultsTree</sender>
+   <signal>allRuleResultsExpanded(bool)</signal>
+   <receiver>MainWindow</receiver>
+   <slot>allRuleResultsExpanded(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>20</x>
+     <y>20</y>
     </hint>
    </hints>
   </connection>

--- a/ui/MainWindow.ui
+++ b/ui/MainWindow.ui
@@ -683,16 +683,6 @@
    <signal>allRuleResultsExpanded(bool)</signal>
    <receiver>MainWindow</receiver>
    <slot>allRuleResultsExpanded(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>20</x>
-     <y>20</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>20</x>
-     <y>20</y>
-    </hint>
-   </hints>
   </connection>
  </connections>
 </ui>


### PR DESCRIPTION
These changes attempt to improve UX of MainWindow

- MainWindow is a bit taller by default
- Added ability to expand and collapse all rules at once
- Labels are bold
- Scan button is more visible
- Changed customization combo box labels
