### PR TITLE
Do not discard colon when reading dowload url

### DIFF
--- a/src/OscapScannerBase.cpp
+++ b/src/OscapScannerBase.cpp
@@ -329,6 +329,11 @@ bool OscapScannerBase::tryToReadStdOutChar(QProcess& process)
                     mReadBuffer = "";
                 }
                 break;
+            case RS_READING_DOWNLOAD_FILE:
+                {
+                    mReadBuffer.append(QChar::fromAscii(readChar));
+                }
+                break;
 
             default:
                 // noop


### PR DESCRIPTION
When fetching remote content, openscap will inform the scap-workbench
about resources being downloaded. The colon in the http URL of the
resource was being removed