### PR TITLE
Check capabilities of oscap with propper arguments

### DIFF
--- a/src/OscapScannerLocal.cpp
+++ b/src/OscapScannerLocal.cpp
@@ -47,7 +47,7 @@ void OscapScannerLocal::evaluate()
     {
         SyncProcess proc(this);
         proc.setCommand(SCAP_WORKBENCH_LOCAL_OSCAP_PATH);
-        proc.setArguments(QStringList("--v"));
+        proc.setArguments(QStringList("-V"));
         proc.run();
 
         if (proc.getExitCode() != 0)

--- a/src/OscapScannerRemoteSsh.cpp
+++ b/src/OscapScannerRemoteSsh.cpp
@@ -112,7 +112,7 @@ void OscapScannerRemoteSsh::evaluate()
     {
         SshSyncProcess proc(mSshConnection, this);
         proc.setCommand(SCAP_WORKBENCH_REMOTE_OSCAP_PATH);
-        proc.setArguments(QStringList("--v"));
+        proc.setArguments(QStringList("-V"));
         proc.setCancelRequestSource(&mCancelRequested);
         proc.run();
 


### PR DESCRIPTION
Check capabilities of oscap by checking its version with
command `oscap -V`