### PR TITLE
Fix --fetch-remote-resources warning with older openscap

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ include(${QT_USE_FILE})
 # custom openscap parameters.
 if (NOT DEFINED OPENSCAP_LIBRARIES OR NOT DEFINED OPENSCAP_INCLUDE_DIRS)
     include("${CMAKE_ROOT}/Modules/FindPkgConfig.cmake")
-    pkg_check_modules(OPENSCAP REQUIRED libopenscap>=1.2.11)
+    pkg_check_modules(OPENSCAP REQUIRED libopenscap>=1.2.0)
 endif()
 
 # Local scanning tools

--- a/doc/user_manual.adoc
+++ b/doc/user_manual.adoc
@@ -29,7 +29,7 @@ image::intro_screenshot.png[align="center"]
 
  * cmake >= 2.6
  * Qt4 (Core, GUI, XmlPatterns)
- * openscap >= 1.2.11
+ * openscap >= 1.2.0
  * cmake-gui [optional]
 
 === Runtime Dependencies (workbench machine)

--- a/src/OscapScannerBase.cpp
+++ b/src/OscapScannerBase.cpp
@@ -451,7 +451,7 @@ QString OscapScannerBase::guiFriendlyMessage(const QString& cliMessage)
     // Remove "WARNING:" prefix and trailing \n
     guiMessage.remove(QRegExp("(WARNING: )|\n"));
 
-    if (cliMessage.contains("--fetch-remote-resource"))
+    if (cliMessage.contains("--fetch-remote-resources"))
         guiMessage = QString("Remote resources might be necessary for this profile to work properly. Please select \"Fetch remote resources\" for complete scan");
     return guiMessage;
 }


### PR DESCRIPTION
These changes makes workbench handle nicely a --fetch-remote-resources
warning message received through stdout.

This fix the use case when SCAP Workbench is running a scan in a machine 
with openscap prior to version 1.2.11.

This also removes the dependency over OpenSCAP 1.2.11 at compile time.