### PR TITLE
Comment why keep colon when reading download file

### DIFF
--- a/src/OscapScannerBase.cpp
+++ b/src/OscapScannerBase.cpp
@@ -331,6 +331,8 @@ bool OscapScannerBase::tryToReadStdOutChar(QProcess& process)
                 break;
             case RS_READING_DOWNLOAD_FILE:
                 {
+                    // When fetching remote content, openscap will inform scap-workbench about
+                    // resources being downloaded. Keep any colon found in URL of file being downloaded.
                     mReadBuffer.append(QChar::fromAscii(readChar));
                 }
                 break;


### PR DESCRIPTION
Better document why we keep colon when reading stdout from openscap
and reading status is RS_READING_DOWNLOAD_FILE.