### PR TITLE
Fixes GitHub issue #109

### DIFF
--- a/include/RemoteMachineComboBox.h
+++ b/include/RemoteMachineComboBox.h
@@ -28,6 +28,7 @@
 #include <QMenu>
 #include <QStringList>
 #include <QSettings>
+#include <QComboBox>
 
 #include "ui_RemoteMachineComboBox.h"
 

--- a/src/RemoteMachineComboBox.cpp
+++ b/src/RemoteMachineComboBox.cpp
@@ -81,7 +81,7 @@ void RemoteMachineComboBox::notifyTargetUsed(const QString& target)
 
     const unsigned int machineCount = getRecentMachineCount();
 
-    // this moves target to the beginning of the list of it was in the list already
+    // this moves target to the beginning of the list if it was in the list already
     mRecentTargets.prepend(target);
     mRecentTargets.removeDuplicates();
 
@@ -89,6 +89,9 @@ void RemoteMachineComboBox::notifyTargetUsed(const QString& target)
 
     syncToQSettings();
     syncRecentMenu();
+
+    // we can be sure there is at least 2 itens in ComboBox, "Recent" and the last entered host
+    mRecentComboBox->setCurrentIndex(1);
 }
 
 void RemoteMachineComboBox::clearHistory()


### PR DESCRIPTION
When the scan is started, the current host, port and the index of "Recent" combobox are reset.

Signed-off-by: Wesley Ceraso Prudencio <wcerasop@redhat.com>