### PR TITLE
Reads "Downloading ..." message from stderr

### DIFF
--- a/src/OscapScannerBase.cpp
+++ b/src/OscapScannerBase.cpp
@@ -306,6 +306,7 @@ bool OscapScannerBase::tryToReadStdOutChar(QProcess& process)
         {
             case RS_READING_PREFIX:
                 {
+                    // Openscap <= 1.2.10 (60fb9f0c98eee) sends this message through stdout
                     if (mReadBuffer=="Downloading")
                     {
                          mReadingState = RS_READING_DOWNLOAD_FILE;
@@ -434,6 +435,11 @@ void OscapScannerBase::watchStdErr(QProcess& process)
             {
                 QString guiMessage = guiFriendlyMessage(stdErrOutput);
                 emit warningMessage(QObject::tr(guiMessage.toUtf8().constData()));
+            }
+            // Openscap >= 1.2.11 (60fb9f0c98eee) sends this message through stderr
+            else if (stdErrOutput.contains(QRegExp("^Downloading: .+ \\.{3} \\w+\\n")))
+            {
+                emit infoMessage(stdErrOutput);
             }
             else
             {


### PR DESCRIPTION
Oscap used to send this message through stdout. When it changed to stderr workbench was not updated.

Signed-off-by: Wesley Ceraso Prudencio <wcerasop@redhat.com>