### PR TITLE
Fixes the focus of remote machine section

### DIFF
--- a/ui/MainWindow.ui
+++ b/ui/MainWindow.ui
@@ -222,7 +222,7 @@
        <item row="11" column="0" colspan="3">
         <widget class="RemoteMachineComboBox" name="remoteMachineDetails" native="true">
          <property name="focusPolicy">
-          <enum>Qt::TabFocus</enum>
+          <enum>Qt::StrongFocus</enum>
          </property>
         </widget>
        </item>


### PR DESCRIPTION
Because of the TabFocus, clicks were not reaching the "User and host" field.

Signed-off-by: Wesley Ceraso Prudencio <wcerasop@redhat.com>