### PR TITLE
Fixes Cancel process

### DIFF
--- a/scap-workbench-oscap.sh
+++ b/scap-workbench-oscap.sh
@@ -18,7 +18,7 @@
 
 set -u -o pipefail
 
-trap "" SIGHUP SIGINT SIGTERM
+trap "" SIGHUP SIGINT
 
 # pkexec writes a message to stderr when user dismisses it, we always skip 1 line.
 # if user did not dismiss it we should print a dummy line to stderr so that nothing
@@ -74,7 +74,7 @@ while kill -0 $PID 2> /dev/null; do
     ret=$?
     if [ 0 -lt $ret -a $ret -lt 128 ]; then
         # If read failed & it was not due to timeout --> parents are gone.
-        kill -s SIGINT $PID 2> /dev/null
+        kill -s SIGTERM $PID 2> /dev/null
         break
     fi
 done

--- a/src/OscapScannerLocal.cpp
+++ b/src/OscapScannerLocal.cpp
@@ -187,7 +187,7 @@ void OscapScannerLocal::evaluate()
         mCancelRequested = true;
     }
 
-    const unsigned int pollInterval = 100;
+    unsigned int pollInterval = 100;
 
     emit infoMessage(QObject::tr("Processing..."));
     while (!process.waitForFinished(pollInterval))
@@ -201,10 +201,9 @@ void OscapScannerLocal::evaluate()
 
         if (mCancelRequested)
         {
+            pollInterval = 1000;
             emit infoMessage(QObject::tr("Cancellation was requested! Terminating scanning..."));
             process.kill();
-            process.waitForFinished(1000);
-            break;
         }
     }
 
@@ -240,6 +239,10 @@ void OscapScannerLocal::evaluate()
 
             emit infoMessage(QObject::tr("Processing has been finished!"));
         }
+    }
+    else
+    {
+        emit infoMessage(QObject::tr("Scanning cancelled!"));
     }
 
     signalCompletion(mCancelRequested);


### PR DESCRIPTION
The cancel process kills the top most pkexec script, the oscap script notices it and try to send a SIGINT to the oscap tool, however, because of the SIGNAL trap and because SIGINT would never reach the oscap tool (even without the trap) everything keeps running.

Reference from bash manpage:
Non-builtin commands run by bash have signal handlers set to the values inherited by the shell from its parent. When job control is not in effect, asynchronous commands ignore SIGINT and SIGQUIT in addition to these inherited handlers.

Fixes #71

Signed-off-by: Wesley Ceraso Prudencio <wcerasop@redhat.com>