### PR TITLE
Fixes the long time to open TailoringWindow in MacOS

### DIFF
--- a/src/TailoringWindow.cpp
+++ b/src/TailoringWindow.cpp
@@ -664,6 +664,9 @@ void TailoringWindow::syncCollapsedItem(QTreeWidgetItem* item, QSet<QString>& us
 {
     struct xccdf_item* xccdfItem = getXccdfItemFromTreeItem(item);
     const QString id = QString::fromUtf8(xccdf_item_get_id(xccdfItem));
+    
+    for (int i = 0; i < item->childCount(); ++i)
+        syncCollapsedItem(item->child(i), usedCollapsedIds);
 
     if (mCollapsedItemIds.contains(id))
     {
@@ -674,9 +677,6 @@ void TailoringWindow::syncCollapsedItem(QTreeWidgetItem* item, QSet<QString>& us
     {
         mUI.itemsTree->expandItem(item);
     }
-
-    for (int i = 0; i < item->childCount(); ++i)
-        syncCollapsedItem(item->child(i), usedCollapsedIds);
 }
 
 void TailoringWindow::createTreeItem(QTreeWidgetItem* treeItem, struct xccdf_item* xccdfItem)


### PR DESCRIPTION
There seems to be a bug in Qt (MacOS implementation) when it tries to calculate geometry/draw tri-state checkboxes that makes it spend much more time than usual.

This commit changes the traversal of the tree from preorder to postorder so that we set the items as expanded while they are still invisible, thus avoiding the geometry calculation and drawing. Only when the top-most item is expanded that all items are drawed, once.

Signed-off-by: Wesley Ceraso Prudencio <wcerasop@redhat.com>