### PR TITLE
Evaluates --skip-valid argument before loading file passed as argument

### DIFF
--- a/include/Application.h
+++ b/include/Application.h
@@ -72,8 +72,6 @@ class Application : public QApplication
 
         /// Whether the application should quit
         bool mShouldQuit;
-
-        bool mSkipValid;
         /// Needed for QObject::tr(..) to work properly, loaded on app startup
         QTranslator mTranslator;
         MainWindow* mMainWindow;

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -32,7 +32,6 @@ Application::Application(int& argc, char** argv):
     QApplication(argc, argv),
 
     mShouldQuit(false),
-    mSkipValid(false),
     mTranslator(),
     mMainWindow(0)
 {
@@ -68,8 +67,6 @@ Application::Application(int& argc, char** argv):
         return;
     }
 
-    mMainWindow->setSkipValid(mSkipValid);
-
     // Only open default content if no file to open was given.
     if (!mMainWindow->fileOpened())
         openSSG();
@@ -99,7 +96,7 @@ void Application::processCLI(QStringList& args)
 
     if (args.contains("--skip-valid"))
     {
-        mSkipValid = true;
+        mMainWindow->setSkipValid(true);
         args.removeAll("--skip-valid");
     }
 


### PR DESCRIPTION
If a file is passed as argument, it is loaded at the end of processCLI function, before the skip-valid option is set to the mainWindow.

Signed-off-by: Wesley Ceraso Prudencio <wcerasop@redhat.com>