### PR TITLE
Port needs to be unsigned short, otherwise we run risks of overflow

### DIFF
--- a/include/OscapScannerRemoteSsh.h
+++ b/include/OscapScannerRemoteSsh.h
@@ -31,7 +31,7 @@ class OscapScannerRemoteSsh : public OscapScannerBase
     Q_OBJECT
 
     public:
-        static void splitTarget(const QString& in, QString& target, short& port);
+        static void splitTarget(const QString& in, QString& target, unsigned short& port);
 
         OscapScannerRemoteSsh();
         virtual ~OscapScannerRemoteSsh();

--- a/src/OscapScannerRemoteSsh.cpp
+++ b/src/OscapScannerRemoteSsh.cpp
@@ -46,7 +46,7 @@ OscapScannerRemoteSsh::OscapScannerRemoteSsh():
 OscapScannerRemoteSsh::~OscapScannerRemoteSsh()
 {}
 
-void OscapScannerRemoteSsh::splitTarget(const QString& in, QString& target, short& port)
+void OscapScannerRemoteSsh::splitTarget(const QString& in, QString& target, unsigned short& port)
 {
     // NB: We dodge a bullet here because the editor will always pass a port
     //     as the last component. A lot of checking and parsing does not need
@@ -63,7 +63,7 @@ void OscapScannerRemoteSsh::splitTarget(const QString& in, QString& target, shor
 
     {
         bool status = false;
-        const short portCandidate = portString.toShort(&status, 10);
+        const unsigned short portCandidate = portString.toUShort(&status, 10);
 
         // FIXME: Error reporting?
         port = status ? portCandidate : 22;
@@ -80,7 +80,7 @@ void OscapScannerRemoteSsh::setTarget(const QString& target)
         mSshConnection.disconnect();
 
     QString cleanTarget;
-    short port;
+    unsigned short port;
 
     splitTarget(target, cleanTarget, port);
 

--- a/src/RemoteMachineComboBox.cpp
+++ b/src/RemoteMachineComboBox.cpp
@@ -73,7 +73,7 @@ unsigned int RemoteMachineComboBox::getRecentMachineCount() const
 void RemoteMachineComboBox::notifyTargetUsed(const QString& target)
 {
     QString host;
-    short port;
+    unsigned short port;
     OscapScannerRemoteSsh::splitTarget(target, host, port);
 
     // skip invalid suggestions
@@ -171,7 +171,7 @@ void RemoteMachineComboBox::updateHostPort(int index)
 
 
     QString host;
-    short port;
+    unsigned short port;
 
     OscapScannerRemoteSsh::splitTarget(target, host, port);
 


### PR DESCRIPTION
60000 is a valid port but can't be represented via just "short".

Fixes #140 