### PR TITLE
Generate bash and ansible remediation roles from profiles

### DIFF
--- a/include/MainWindow.h
+++ b/include/MainWindow.h
@@ -420,9 +420,9 @@ class MainWindow : public QMainWindow
         void toggleRuleResultsExpanded();
         void toggleRuleResultsExpanded(bool checked);
 
-        /// Pops up a save dialog for a bash remediation
+        /// Pops up a save dialog for a bash remediation (based just on the currently selected profile)
         void generateBashRemediationRole();
-        /// Pops up a save dialog for an ansible remediation
+        /// Pops up a save dialog for an ansible remediation (based just on the currently selected profile)
         void generateAnsibleRemediationRole();
 
     public slots:

--- a/include/MainWindow.h
+++ b/include/MainWindow.h
@@ -424,6 +424,8 @@ class MainWindow : public QMainWindow
         void generateBashRemediationRole();
         /// Pops up a save dialog for an ansible remediation (based just on the currently selected profile)
         void generateAnsibleRemediationRole();
+        /// Pops up a save dialog for an puppet remediation (based just on the currently selected profile)
+        void generatePuppetRemediationRole();
 
     public slots:
         /**

--- a/include/MainWindow.h
+++ b/include/MainWindow.h
@@ -421,9 +421,9 @@ class MainWindow : public QMainWindow
         void toggleRuleResultsExpanded(bool checked);
 
         /// Pops up a save dialog for a bash remediation
-        void genBash();
+        void generateBashRemediationRole();
         /// Pops up a save dialog for an ansible remediation
-        void genAnsible();
+        void generateAnsibleRemediationRole();
 
     public slots:
         /**

--- a/include/MainWindow.h
+++ b/include/MainWindow.h
@@ -420,6 +420,11 @@ class MainWindow : public QMainWindow
         void toggleRuleResultsExpanded();
         void toggleRuleResultsExpanded(bool checked);
 
+        /// Pops up a save dialog for a bash remediation
+        void genBash();
+        /// Pops up a save dialog for an ansible remediation
+        void genAnsible();
+
     public slots:
         /**
          * @brief Changes state of Expand all/Collapse all button according to boolean received

--- a/include/RemediationRoleSaver.h
+++ b/include/RemediationRoleSaver.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 Red Hat Inc., Durham, North Carolina.
+ * Copyright 2017 Red Hat Inc., Durham, North Carolina.
  * All Rights Reserved.
  *
  * This program is free software: you can redistribute it and/or modify
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  * Authors:
- *      Martin Preisler <mpreisle@redhat.com>
+ *      Matej Tyc <matyc@redhat.com>
  */
 
 #ifndef SCAP_WORKBENCH_REMEDIATION_ROLE_SAVER_H_
@@ -40,8 +40,9 @@ extern "C"
 class RemediationSaverBase
 {
     public:
-    RemediationSaverBase(QWidget* parentWindow, ScanningSession* session): mParentWindow(parentWindow), mScanningSession(session) {}
-        void SelectFilenameAndSaveRole();
+        RemediationSaverBase(QWidget* parentWindow, ScanningSession* session):
+            mParentWindow(parentWindow), mScanningSession(session) {}
+        void selectFilenameAndSaveRole();
 
     protected:
         const ScanningSession* mScanningSession;
@@ -53,8 +54,8 @@ class RemediationSaverBase
         QString mFixTemplate;
 
     private:
-        int SaveToFile(const QString& filename);
-        QString guessFilenameStem();
+        int saveToFile(const QString& filename);
+        QString guessFilenameStem() const;
 };
 
 

--- a/include/RemediationRoleSaver.h
+++ b/include/RemediationRoleSaver.h
@@ -1,0 +1,65 @@
+#ifndef SCAP_WORKBENCH_REMEDIATION_ROLE_SAVER_H_
+#define SCAP_WORKBENCH_REMEDIATION_ROLE_SAVER_H_
+
+#include "ForwardDecls.h"
+#include "ScanningSession.h"
+
+#include <QString>
+#include <QFile>
+#include <QFileDialog>
+
+extern "C"
+{
+#include <xccdf_benchmark.h>
+#include <xccdf_policy.h>
+#include <xccdf_session.h>
+}
+
+
+class RemediationSaverBase
+{
+    public:
+	RemediationSaverBase(QWidget* parentWindow, ScanningSession* session): mParentWindow(parentWindow), mScanningSession(session) {}
+        void SelectFilenameAndSaveRole();
+
+    protected:
+        const ScanningSession* mScanningSession;
+        QWidget* mParentWindow;
+
+        QString mSaveMessage;
+        QString mFiletypeExtension;
+        QString mFiletypeTemplate;
+        QString mFixTemplate;
+
+    private:
+        int SaveToFile(const QString& filename);
+        QString guessFilenameStem();
+};
+
+
+class BashRemediationSaver : public RemediationSaverBase
+{
+    public:
+	BashRemediationSaver(QWidget* parentWindow, ScanningSession* session):RemediationSaverBase(parentWindow, session)
+	{
+	    mSaveMessage = QObject::tr("Save remediation role as a bash script");
+	    mFiletypeExtension = "sh";
+	    mFiletypeTemplate = QObject::tr("bash script (*.%1)");
+	    mFixTemplate = QObject::tr("urn:xccdf:fix:script:sh");
+        }
+};
+
+
+class AnsibleRemediationSaver : public RemediationSaverBase
+{
+    public:
+	AnsibleRemediationSaver(QWidget* parentWindow, ScanningSession* session):RemediationSaverBase(parentWindow, session)
+	{
+	    mSaveMessage = QObject::tr("Save remediation role as an ansible playbook");
+	    mFiletypeExtension = "yml";
+	    mFiletypeTemplate = QObject::tr("ansible playbook (*.%1)");
+	    mFixTemplate = QObject::tr("urn:xccdf:fix:script:ansible");
+        }
+};
+
+#endif // SCAP_WORKBENCH_REMEDIATION_ROLE_SAVER_H_

--- a/include/RemediationRoleSaver.h
+++ b/include/RemediationRoleSaver.h
@@ -1,3 +1,24 @@
+/*
+ * Copyright 2013 Red Hat Inc., Durham, North Carolina.
+ * All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ *      Martin Preisler <mpreisle@redhat.com>
+ */
+
 #ifndef SCAP_WORKBENCH_REMEDIATION_ROLE_SAVER_H_
 #define SCAP_WORKBENCH_REMEDIATION_ROLE_SAVER_H_
 
@@ -19,7 +40,7 @@ extern "C"
 class RemediationSaverBase
 {
     public:
-	RemediationSaverBase(QWidget* parentWindow, ScanningSession* session): mParentWindow(parentWindow), mScanningSession(session) {}
+    RemediationSaverBase(QWidget* parentWindow, ScanningSession* session): mParentWindow(parentWindow), mScanningSession(session) {}
         void SelectFilenameAndSaveRole();
 
     protected:
@@ -40,26 +61,14 @@ class RemediationSaverBase
 class BashRemediationSaver : public RemediationSaverBase
 {
     public:
-	BashRemediationSaver(QWidget* parentWindow, ScanningSession* session):RemediationSaverBase(parentWindow, session)
-	{
-	    mSaveMessage = QObject::tr("Save remediation role as a bash script");
-	    mFiletypeExtension = "sh";
-	    mFiletypeTemplate = QObject::tr("bash script (*.%1)");
-	    mFixTemplate = QObject::tr("urn:xccdf:fix:script:sh");
-        }
+        BashRemediationSaver(QWidget* parentWindow, ScanningSession* session);
 };
 
 
 class AnsibleRemediationSaver : public RemediationSaverBase
 {
     public:
-	AnsibleRemediationSaver(QWidget* parentWindow, ScanningSession* session):RemediationSaverBase(parentWindow, session)
-	{
-	    mSaveMessage = QObject::tr("Save remediation role as an ansible playbook");
-	    mFiletypeExtension = "yml";
-	    mFiletypeTemplate = QObject::tr("ansible playbook (*.%1)");
-	    mFixTemplate = QObject::tr("urn:xccdf:fix:script:ansible");
-        }
+        AnsibleRemediationSaver(QWidget* parentWindow, ScanningSession* session);
 };
 
 #endif // SCAP_WORKBENCH_REMEDIATION_ROLE_SAVER_H_

--- a/include/RemediationRoleSaver.h
+++ b/include/RemediationRoleSaver.h
@@ -45,7 +45,7 @@ class RemediationSaverBase
         QString mFixTemplate;
 
     private:
-        int saveToFile(const QString& filename);
+        void saveToFile(const QString& filename);
         QString guessFilenameStem() const;
 };
 

--- a/include/RemediationRoleSaver.h
+++ b/include/RemediationRoleSaver.h
@@ -26,22 +26,13 @@
 #include "ScanningSession.h"
 
 #include <QString>
-#include <QFile>
 #include <QFileDialog>
-
-extern "C"
-{
-#include <xccdf_benchmark.h>
-#include <xccdf_policy.h>
-#include <xccdf_session.h>
-}
 
 
 class RemediationSaverBase
 {
     public:
-        RemediationSaverBase(QWidget* parentWindow, ScanningSession* session):
-            mParentWindow(parentWindow), mScanningSession(session) {}
+        RemediationSaverBase(QWidget* parentWindow, ScanningSession* session);
         void selectFilenameAndSaveRole();
 
     protected:
@@ -71,5 +62,12 @@ class AnsibleRemediationSaver : public RemediationSaverBase
     public:
         AnsibleRemediationSaver(QWidget* parentWindow, ScanningSession* session);
 };
+
+class PuppetRemediationSaver : public RemediationSaverBase
+{
+    public:
+        PuppetRemediationSaver(QWidget* parentWindow, ScanningSession* session);
+};
+
 
 #endif // SCAP_WORKBENCH_REMEDIATION_ROLE_SAVER_H_

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -1552,15 +1552,14 @@ QMessageBox::StandardButton MainWindow::openNewFileQuestionDialog(const QString&
     );
 }
 
-// TODO: Reuse code between generateBashRemediationRole and generateAnsibleRemediationRole
 void MainWindow::generateBashRemediationRole()
 {
     BashRemediationSaver saver(this, mScanningSession);
-    saver.SelectFilenameAndSaveRole();
+    saver.selectFilenameAndSaveRole();
 }
 
 void MainWindow::generateAnsibleRemediationRole()
 {
     AnsibleRemediationSaver saver(this, mScanningSession);
-    saver.SelectFilenameAndSaveRole();
+    saver.selectFilenameAndSaveRole();
 }

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -260,12 +260,16 @@ MainWindow::MainWindow(QWidget* parent):
         genAnsibleRemediation, SIGNAL(triggered()),
         this, SLOT(generateAnsibleRemediationRole())
     );
+    QAction* genPuppetRemediation = new QAction("&puppet", this);
+    QObject::connect(
+        genPuppetRemediation, SIGNAL(triggered()),
+        this, SLOT(generatePuppetRemediationRole())
+    );
 
     QMenu* remediationButtonMenu = new QMenu(this);
     remediationButtonMenu->addAction(genBashRemediation);
     remediationButtonMenu->addAction(genAnsibleRemediation);
-    // remediationButtonMenu->addAction(mGenPuppetRemediation);
-    // remediationButtonMenu->addAction(mGenAnacondaRemediation);
+    remediationButtonMenu->addAction(genPuppetRemediation);
     mUI.genRemediationButton->setMenu(remediationButtonMenu);
 }
 
@@ -1561,5 +1565,11 @@ void MainWindow::generateBashRemediationRole()
 void MainWindow::generateAnsibleRemediationRole()
 {
     AnsibleRemediationSaver saver(this, mScanningSession);
+    saver.selectFilenameAndSaveRole();
+}
+
+void MainWindow::generatePuppetRemediationRole()
+{
+    PuppetRemediationSaver saver(this, mScanningSession);
     saver.selectFilenameAndSaveRole();
 }

--- a/src/RemediationRoleSaver.cpp
+++ b/src/RemediationRoleSaver.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 Red Hat Inc., Durham, North Carolina.
+ * Copyright 2017 Red Hat Inc., Durham, North Carolina.
  * All Rights Reserved.
  *
  * This program is free software: you can redistribute it and/or modify
@@ -16,12 +16,12 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  * Authors:
- *      Martin Preisler <mpreisle@redhat.com>
+ *      Matej Tyc <matyc@redhat.com>
  */
 
 #include "RemediationRoleSaver.h"
 
-void RemediationSaverBase::SelectFilenameAndSaveRole()
+void RemediationSaverBase::selectFilenameAndSaveRole()
 {
     const QString filename = QFileDialog::getSaveFileName(mParentWindow,
         mSaveMessage.toUtf8(),
@@ -35,7 +35,7 @@ void RemediationSaverBase::SelectFilenameAndSaveRole()
     if (filename.isEmpty())
         return;
 
-    int result = SaveToFile(filename);
+    const int result = saveToFile(filename);
     if (result == 0)
     {
         // TODO: if OK
@@ -46,7 +46,7 @@ void RemediationSaverBase::SelectFilenameAndSaveRole()
     }
 }
 
-int RemediationSaverBase::SaveToFile(const QString& filename)
+int RemediationSaverBase::saveToFile(const QString& filename)
 {
     QFile outputFile(filename);
     outputFile.open(QIODevice::WriteOnly);
@@ -57,7 +57,7 @@ int RemediationSaverBase::SaveToFile(const QString& filename)
     return result;
 }
 
-QString RemediationSaverBase::guessFilenameStem()
+QString RemediationSaverBase::guessFilenameStem() const
 {
     // TODO: Add guess that uses benchmark and profile names
     return QString("remediation");

--- a/src/RemediationRoleSaver.cpp
+++ b/src/RemediationRoleSaver.cpp
@@ -1,0 +1,43 @@
+#include "RemediationRoleSaver.h"
+
+void RemediationSaverBase::SelectFilenameAndSaveRole()
+{
+    const QString filename = QFileDialog::getSaveFileName(mParentWindow,
+        mSaveMessage.toUtf8(),
+        QString("%1.%2").arg(guessFilenameStem()).arg(mFiletypeExtension),
+        mFiletypeTemplate.arg(mFiletypeExtension), 0
+#ifndef SCAP_WORKBENCH_USE_NATIVE_FILE_DIALOGS
+        , QFileDialog::DontUseNativeDialog
+#endif
+    );
+
+    if (filename.isEmpty())
+        return;
+
+    int result = SaveToFile(filename);
+    if (result == 0)
+    {
+        // TODO: if OK
+    }
+    else
+    {
+        // TODO: if not OK
+    }
+}
+
+int RemediationSaverBase::SaveToFile(const QString& filename)
+{
+    QFile outputFile(filename);
+    outputFile.open(QIODevice::WriteOnly);
+    struct xccdf_session* session = mScanningSession->getXCCDFSession();
+    struct xccdf_policy* policy = xccdf_session_get_xccdf_policy(session);
+    int result = xccdf_policy_generate_fix(policy, NULL, mFixTemplate.toUtf8(), outputFile.handle());
+    outputFile.close();
+    return result;
+}
+
+QString RemediationSaverBase::guessFilenameStem()
+{
+    // TODO: Add guess that uses benchmark and profile names
+    return QString("remediation");
+}

--- a/src/RemediationRoleSaver.cpp
+++ b/src/RemediationRoleSaver.cpp
@@ -1,3 +1,24 @@
+/*
+ * Copyright 2013 Red Hat Inc., Durham, North Carolina.
+ * All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ *      Martin Preisler <mpreisle@redhat.com>
+ */
+
 #include "RemediationRoleSaver.h"
 
 void RemediationSaverBase::SelectFilenameAndSaveRole()
@@ -40,4 +61,22 @@ QString RemediationSaverBase::guessFilenameStem()
 {
     // TODO: Add guess that uses benchmark and profile names
     return QString("remediation");
+}
+
+
+BashRemediationSaver::BashRemediationSaver(QWidget* parentWindow, ScanningSession* session):RemediationSaverBase(parentWindow, session)
+{
+    mSaveMessage = QObject::tr("Save remediation role as a bash script");
+    mFiletypeExtension = "sh";
+    mFiletypeTemplate = QObject::tr("bash script (*.%1)");
+    mFixTemplate = QObject::tr("urn:xccdf:fix:script:sh");
+}
+
+
+AnsibleRemediationSaver::AnsibleRemediationSaver(QWidget* parentWindow, ScanningSession* session):RemediationSaverBase(parentWindow, session)
+{
+    mSaveMessage = QObject::tr("Save remediation role as an ansible playbook");
+    mFiletypeExtension = "yml";
+    mFiletypeTemplate = QObject::tr("ansible playbook (*.%1)");
+    mFixTemplate = QObject::tr("urn:xccdf:fix:script:ansible");
 }

--- a/src/RemediationRoleSaver.cpp
+++ b/src/RemediationRoleSaver.cpp
@@ -62,7 +62,7 @@ void RemediationSaverBase::selectFilenameAndSaveRole()
     }
 }
 
-int RemediationSaverBase::saveToFile(const QString& filename)
+void RemediationSaverBase::saveToFile(const QString& filename)
 {
     QFile outputFile(filename);
     outputFile.open(QIODevice::WriteOnly);
@@ -77,7 +77,6 @@ int RemediationSaverBase::saveToFile(const QString& filename)
             err = "Unknown error";
         throw std::runtime_error(err);
     }
-    return result;
 }
 
 QString RemediationSaverBase::guessFilenameStem() const

--- a/ui/MainWindow.ui
+++ b/ui/MainWindow.ui
@@ -360,10 +360,10 @@
              <item>
               <widget class="QPushButton" name="genRemediationButton">
                <property name="toolTip">
-                <string>Generate remediations of all possible failiures that the selected profile can cover.</string>
+                <string>Generate remediation role that contains fix for every single rule the in the profile. Note that not every rule implements a fix.</string>
                </property>
                <property name="text">
-                <string>Get profile remediations</string>
+                <string>Generate remediation role</string>
                </property>
               </widget>
              </item>

--- a/ui/MainWindow.ui
+++ b/ui/MainWindow.ui
@@ -184,7 +184,16 @@
           </sizepolicy>
          </property>
          <layout class="QHBoxLayout" name="horizontalLayout_5">
-          <property name="margin">
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
            <number>0</number>
           </property>
           <item>
@@ -314,19 +323,47 @@
        <item>
         <widget class="QWidget" name="widget_5" native="true">
          <layout class="QVBoxLayout" name="verticalLayout_3">
-          <property name="margin">
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
            <number>0</number>
           </property>
           <item>
            <widget class="QWidget" name="preScanTools" native="true">
             <layout class="QHBoxLayout" name="horizontalLayout">
-             <property name="margin">
+             <property name="leftMargin">
+              <number>0</number>
+             </property>
+             <property name="topMargin">
+              <number>0</number>
+             </property>
+             <property name="rightMargin">
+              <number>0</number>
+             </property>
+             <property name="bottomMargin">
               <number>0</number>
              </property>
              <item>
               <widget class="QPushButton" name="showGuideButton">
                <property name="text">
                 <string>Show Guide</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QPushButton" name="genRemediationButton">
+               <property name="toolTip">
+                <string>Generate remediations of all possible failiures that the selected profile can cover.</string>
+               </property>
+               <property name="text">
+                <string>Get profile remediations</string>
                </property>
               </widget>
              </item>
@@ -396,7 +433,16 @@
           <item>
            <widget class="QWidget" name="scanTools" native="true">
             <layout class="QHBoxLayout" name="horizontalLayout_4">
-             <property name="margin">
+             <property name="leftMargin">
+              <number>0</number>
+             </property>
+             <property name="topMargin">
+              <number>0</number>
+             </property>
+             <property name="rightMargin">
+              <number>0</number>
+             </property>
+             <property name="bottomMargin">
               <number>0</number>
              </property>
              <item>
@@ -438,7 +484,16 @@
           <item>
            <widget class="QWidget" name="postScanTools" native="true">
             <layout class="QHBoxLayout" name="horizontalLayout_3">
-             <property name="margin">
+             <property name="leftMargin">
+              <number>0</number>
+             </property>
+             <property name="topMargin">
+              <number>0</number>
+             </property>
+             <property name="rightMargin">
+              <number>0</number>
+             </property>
+             <property name="bottomMargin">
               <number>0</number>
              </property>
              <item>
@@ -511,7 +566,7 @@
      <x>0</x>
      <y>0</y>
      <width>800</width>
-     <height>27</height>
+     <height>29</height>
     </rect>
    </property>
    <property name="font">


### PR DESCRIPTION
Before this PR, S-W was able to remediate on the fly or remediate after the check using `oscap`.
This PR aims to enable users to control the remediation by giving them access to remediation scripts (that they can edit and execute by themselves).

EDIT by @mpreisler: Let's only do generate from profiles here and generate from results can be in a separate PR.