### PR TITLE
pkg-config path needed if openscap is compiled locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ optional dependencies:
 2) Build SCAP Workbench:
 ```console
 $ mkdir build; cd build
+$ # this export line is only required if openscap was
+$ # compiled locally and libopenscap is in /usr/local/lib/
+$ export PKG_CONFIG_PATH=/PATH/TO/YOUR/SOURCE/openscap/
 $ cmake ../
 $ make
 ```

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ optional dependencies:
 ```console
 $ mkdir build; cd build
 $ # This export line is only required if openscap was compiled locally;
-$ # add to PKG_CONFIG_PATH the directory containing libopenscap.pc
-$ export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:/PATH/TO/DIR/WITH/.pcFILE/
+$ # add to PKG_CONFIG_PATH the directory containing installed libopenscap.pc
+$ export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/PATH/TO/DIR/WITH/.pcFILE/"
 $ cmake ../
 $ make
 ```

--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ optional dependencies:
 2) Build SCAP Workbench:
 ```console
 $ mkdir build; cd build
-$ # this export line is only required if openscap was
-$ # compiled locally and libopenscap is in /usr/local/lib/
-$ export PKG_CONFIG_PATH=/PATH/TO/YOUR/SOURCE/openscap/
+$ # This export line is only required if openscap was compiled locally;
+$ # add to PKG_CONFIG_PATH the directory containing libopenscap.pc
+$ export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:/PATH/TO/DIR/WITH/.pcFILE/
 $ cmake ../
 $ make
 ```


### PR DESCRIPTION
As mentioned recently on the mailing list:
> I've compiled openscap and the SSG locally and they work great. I'd like to try scap-workbench but cmake complains "No package 'libopenscap' found" despite having run "make install" on openscap.

Openscap comes with a `libopenscap.pc` file, but `pkg-config` can't find it. The fix is simple and included here in the README.
