### PR TITLE
Reflect qt5-devel dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ How to run it out of the box
 
 required dependencies:
 ```console
-# yum install cmake gcc-c++ openssh-clients util-linux openscap-devel qt-devel
+# yum install cmake gcc-c++ openssh-clients util-linux openscap-devel qt5-devel
 ```
 
 required dependencies (only for the git repo, not required for released tarballs):


### PR DESCRIPTION
Master branch requires `qt5-devel` versus `qt-devel` package to be installed; this reflects that.