### PR TITLE
Add openssh-askpass as a required dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ How to run it out of the box
 
 required dependencies:
 ```console
-# yum install cmake gcc-c++ openssh-clients util-linux openscap-devel qt5-devel
+# yum install cmake gcc-c++ openssh-clients util-linux openscap-devel qt5-devel openssh-askpass
 ```
 
 required dependencies (only for the git repo, not required for released tarballs):


### PR DESCRIPTION
Required for remote ssh scanning. 