### PR TITLE
Better UX around opened content

### DIFF
--- a/include/MainWindow.h
+++ b/include/MainWindow.h
@@ -29,6 +29,7 @@
 #include <QThread>
 #include <QMenu>
 #include <QMessageBox>
+#include <QFileSystemWatcher>
 
 extern "C"
 {
@@ -245,6 +246,10 @@ class MainWindow : public QMainWindow
         /// If true, the profile combobox change signal is ignored, this avoids unnecessary profile refreshes
         bool mIgnoreProfileComboBox;
 
+        /// Implement watching of original XCCDF/DS
+        QFileSystemWatcher* mFSWatch;
+        QString mFSLastSeen;
+
     signals:
         /**
          * @brief We signal this to show the dialog
@@ -390,6 +395,11 @@ class MainWindow : public QMainWindow
         void markRemoveLoadedTailoringFile();
         void markLoadedTailoringFile(const QString& filePath);
         bool unsavedTailoringChanges() const;
+
+        /**
+         * @brief Slot handler for notifying user that opened files changed
+         */
+        void fileChanged(const QString& path);
 
     public:
         QString getDefaultSaveDirectory();

--- a/include/MainWindow.h
+++ b/include/MainWindow.h
@@ -65,7 +65,7 @@ class MainWindow : public QMainWindow
         /**
          * @brief Opens a specific file
          */
-        void openFile(const QString& path);
+        void openFile(const QString& path, bool reload = false);
 
         void openSSGDialog(const QString& customDismissLabel = "");
 
@@ -94,6 +94,15 @@ class MainWindow : public QMainWindow
          * @see MainWindow::closeMainWindow
          */
         void closeMainWindowAsync();
+
+        /**
+         * @bried Reloads the opened content
+         *
+         *
+         * If a content file is opened, it might have changed on disk. This
+         * allows the user to update reload it in case it has changed.
+         */
+        void reloadContent();
 
         /**
          * @brief Checks whether a file is currently opened

--- a/include/ScanningSession.h
+++ b/include/ScanningSession.h
@@ -291,14 +291,14 @@ class ScanningSession
         /// Our own tailoring that may or may not initially be loaded from a file
         mutable struct xccdf_tailoring* mTailoring;
 
-        /// Temporary copy of opened XCCDF file
-        QTemporaryDir* mOpenDir;
-        /// Path to temporary XCCDF file
-        QString mOpenPath;
-        /// Path to original XCCDF file
-        QString mOriginalPath;
-        /// Closure of original XCCDF file
-        QSet<QString> mClosureOfFile;
+        /// Temporary copy of opened DS or XCCDF file
+        QTemporaryDir* mTempOpenDir;
+        /// Path to temporary DS or XCCDF file
+        QString mTempOpenPath;
+        /// Path to original DS or XCCDF file
+        QString mOriginalOpenPath;
+        /// Closure of original DS or XCCDF file
+        QSet<QString> mClosureOfOriginalFile;
 
         /// Temporary file provides auto deletion and a valid temp file path
         QTemporaryFile mTailoringFile;
@@ -319,12 +319,14 @@ class ScanningSession
         QString mUserTailoringCID;
 
         /// Gets the dependency closure of the specified file.
-        void getDependencyClosureOfFile(const QString& filePath, QSet<QString>& targetSet) const;
+        void updateDependencyClosureOfFile(const QString& filePath, QSet<QString>& targetSet) const;
 
         /// Clones openFile(path) to a Temporary File
         void cloneToTemporaryFile(const QString& path);
         /// Closes mOpenFile if it is open
         void cleanTmpDir();
+        /// Copies all files from the path into the temporary location
+        void copyTempFiles(QString path, QString baseDirectory, const QFileInfo pathInfo);
 };
 
 #endif

--- a/include/ScanningSession.h
+++ b/include/ScanningSession.h
@@ -24,6 +24,7 @@
 
 #include "ForwardDecls.h"
 
+#include <QTemporaryDir>
 #include <QTemporaryFile>
 #include <QSet>
 #include <QDir>
@@ -61,7 +62,7 @@ class ScanningSession
          * Passed file may be an XCCDF file (any openscap supported version)
          * or source datastream (SDS) file (any openscap supported version)
          */
-        void openFile(const QString& path);
+        void openFile(const QString& path, bool reload = false);
 
         /**
          * @brief Closes currently opened file (if any)
@@ -280,6 +281,11 @@ class ScanningSession
         /// Our own tailoring that may or may not initially be loaded from a file
         mutable struct xccdf_tailoring* mTailoring;
 
+        /// Temporary copy of opened XCCDF file
+        QTemporaryDir* mOpenDir;
+        /// Path to temporary XCCDF file
+        QString mOpenPath;
+
         /// Temporary file provides auto deletion and a valid temp file path
         QTemporaryFile mTailoringFile;
         /// Temporary file provides auto deletion and a valid temp file path
@@ -297,6 +303,14 @@ class ScanningSession
 
         QString mUserTailoringFile;
         QString mUserTailoringCID;
+
+        /// Gets the dependency closure of the specified file.
+        void getDependencyClosureOfFile(const QString& filePath, QSet<QString>& targetSet) const;
+
+        /// Clones openFile(path) to a Temporary File
+        void cloneToTemporaryFile(const QString& path);
+        /// Closes mOpenFile if it is open
+        void cleanTmpDir();
 };
 
 #endif

--- a/include/ScanningSession.h
+++ b/include/ScanningSession.h
@@ -77,6 +77,11 @@ class ScanningSession
         QString getOpenedFilePath() const;
 
         /**
+         * @brief Retrieves full absolute path of the opened file
+         */
+        QString getOriginalFilePath() const;
+
+        /**
          * @brief A helper method that gets the longest common ancestor dir from a set of paths
          */
         static QDir getCommonAncestorDirectory(const QSet<QString>& paths);
@@ -285,6 +290,8 @@ class ScanningSession
         QTemporaryDir* mOpenDir;
         /// Path to temporary XCCDF file
         QString mOpenPath;
+        /// Path to original XCCDF file
+        QString mOriginalPath;
 
         /// Temporary file provides auto deletion and a valid temp file path
         QTemporaryFile mTailoringFile;

--- a/include/ScanningSession.h
+++ b/include/ScanningSession.h
@@ -82,6 +82,11 @@ class ScanningSession
         QString getOriginalFilePath() const;
 
         /**
+         * @brief Retrives the closure set of the original file
+         */
+        QSet<QString> getOriginalClosure() const;
+
+        /**
          * @brief A helper method that gets the longest common ancestor dir from a set of paths
          */
         static QDir getCommonAncestorDirectory(const QSet<QString>& paths);
@@ -292,6 +297,8 @@ class ScanningSession
         QString mOpenPath;
         /// Path to original XCCDF file
         QString mOriginalPath;
+        /// Closure of original XCCDF file
+        QSet<QString> mClosureOfFile;
 
         /// Temporary file provides auto deletion and a valid temp file path
         QTemporaryFile mTailoringFile;

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -37,6 +37,7 @@
 #include "RemediationRoleSaver.h"
 
 #include <QFileDialog>
+#include <QPushButton>
 #include <QAbstractEventDispatcher>
 #include <QCloseEvent>
 #include <QFileSystemWatcher>
@@ -1558,11 +1559,21 @@ void MainWindow::fileChanged(const QString& path)
         return;
     mFSLastSeen = path;
 
-    QMessageBox::information(
-        this, QObject::tr("SCAP Workbench"),
-        QObject::tr("Opened file was modified after opening: %1\n\n"
-                    "To reload, click File -> Reload Opened Content").arg(path)
-    );
+    QMessageBox question;
+    question.setText(QObject::tr("The following file was modified after opening: %1").arg(path));
+    question.setInformativeText(QObject::tr("Do you wish to reload it, losing any unsaved tailoring changes?"));
+
+    QPushButton *reload = question.addButton(QObject::tr("Reload"), QMessageBox::AcceptRole);
+    QPushButton *ignore = question.addButton(QObject::tr("Ignore"), QMessageBox::RejectRole);
+    question.setDefaultButton(ignore);
+    question.setIcon(QMessageBox::Question);
+
+    question.exec();
+
+    if (question.clickedButton() == reload)
+    {
+        reloadContent();
+    }
 }
 
 QString MainWindow::getDefaultSaveDirectory()

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -448,7 +448,7 @@ void MainWindow::openFileDialog()
 
         if (fileOpened())
         {
-            if (openNewFileQuestionDialog(mScanningSession->getOpenedFilePath()) == QMessageBox::Yes)
+            if (openNewFileQuestionDialog(mScanningSession->getOriginalFilePath()) == QMessageBox::Yes)
                 closeFile();
             else
                 // user cancelled closing current file, we have to abort
@@ -514,7 +514,7 @@ void MainWindow::openSSGDialog(const QString& customDismissLabel)
 
             if (fileOpened())
             {
-                if (openNewFileQuestionDialog(mScanningSession->getOpenedFilePath()) == QMessageBox::Yes)
+                if (openNewFileQuestionDialog(mScanningSession->getOriginalFilePath()) == QMessageBox::Yes)
                 {
                     closeFile();
                 }

--- a/src/ScanningSession.cpp
+++ b/src/ScanningSession.cpp
@@ -128,12 +128,12 @@ void ScanningSession::cloneToTemporaryFile(const QString& path)
     //
     // Files which violate this constraint are rare; thus it should be safe
     // to refuse to open them.
-    QSet<QString> closureOfFile;
-    getDependencyClosureOfFile(path, closureOfFile);
+    mClosureOfFile.clear();
+    getDependencyClosureOfFile(path, mClosureOfFile);
 
     const QFileInfo pathInfo(path);
     QString baseDirectory = pathInfo.absolutePath();
-    for (const QString& cur : closureOfFile)
+    for (const QString& cur : mClosureOfFile)
     {
         // Since getDependencyClosureOfFile(...) returns cleaned absolute
         // paths, we can check if the path starts with the baseDirectory
@@ -154,7 +154,7 @@ void ScanningSession::cloneToTemporaryFile(const QString& path)
     QFile::copy(path, mOpenPath);
 
     QDir tmpDir(tmpPath);
-    for (const QString& cur : closureOfFile)
+    for (const QString& cur : mClosureOfFile)
     {
         const QFileInfo curInfo(cur);
         const QDir curDir = curInfo.absoluteDir();
@@ -253,6 +253,10 @@ QString ScanningSession::getOriginalFilePath() const
     return mOriginalPath;
 }
 
+QSet<QString> ScanningSession::getOriginalClosure() const
+{
+    return mClosureOfFile;
+}
 
 void ScanningSession::getDependencyClosureOfFile(const QString& filePath, QSet<QString>& targetSet) const
 {

--- a/src/ScanningSession.cpp
+++ b/src/ScanningSession.cpp
@@ -186,6 +186,8 @@ void ScanningSession::cloneToTemporaryFile(const QString& path)
             QFile::copy(cur, tmpPath + curInfo.fileName());
         }
     }
+
+    mOriginalPath = path;
 }
 
 void ScanningSession::openFile(const QString& path, bool reload)
@@ -193,7 +195,7 @@ void ScanningSession::openFile(const QString& path, bool reload)
     if (mSession)
         closeFile();
 
-    if (reload || mOpenPath != path)
+    if (reload || mOriginalPath != path)
     {
         cloneToTemporaryFile(path);
     }
@@ -242,6 +244,15 @@ QString ScanningSession::getOpenedFilePath() const
     // therefore this is guaranteed to be absolute
     return xccdf_session_get_filename(mSession);
 }
+
+QString ScanningSession::getOriginalFilePath() const
+{
+    if (!fileOpened())
+        return QString("");
+
+    return mOriginalPath;
+}
+
 
 void ScanningSession::getDependencyClosureOfFile(const QString& filePath, QSet<QString>& targetSet) const
 {

--- a/src/ScanningSession.cpp
+++ b/src/ScanningSession.cpp
@@ -159,8 +159,9 @@ inline void getDependencyClosureOfFile(const QString& filePath, QSet<QString>& t
             {
                 QXmlNodeModelIndex itemIdx = item.toNodeModelIndex();
                 const QAbstractXmlNodeModel* model = itemIdx.model();
-                const QString  relativeFileName = model->stringValue(itemIdx);
-                getDependencyClosureOfFile(parentDir.absoluteFilePath(relativeFileName), targetSet);
+                const QString relativeFileName = model->stringValue(itemIdx);
+                const QString absUncleanPath = parentDir.absoluteFilePath(relativeFileName);
+                getDependencyClosureOfFile(QDir::cleanPath(absUncleanPath), targetSet);
                 item = result.next();
             }
 

--- a/src/ScanningSession.cpp
+++ b/src/ScanningSession.cpp
@@ -34,6 +34,8 @@ extern "C" {
 
 #include <cassert>
 #include <ctime>
+#include <QTemporaryDir>
+#include <QTemporaryFile>
 #include <QFileInfo>
 #include <QBuffer>
 #include <QXmlQuery>
@@ -45,8 +47,11 @@ ScanningSession::ScanningSession():
     mSession(0),
     mTailoring(0),
 
+    mOpenDir(NULL),
+
     mSkipValid(false),
     mSessionDirty(false),
+
     mTailoringUserChanges(false)
 {
     mTailoringFile.setAutoRemove(true);
@@ -54,6 +59,7 @@ ScanningSession::ScanningSession():
 
 ScanningSession::~ScanningSession()
 {
+    cleanTmpDir();
     closeFile();
 }
 
@@ -71,12 +77,129 @@ struct xccdf_session* ScanningSession::getXCCDFSession() const
     return mSession;
 }
 
-void ScanningSession::openFile(const QString& path)
+void ScanningSession::cleanTmpDir()
+{
+    /*
+     * For use in cloneToTemporaryFile(...); closes mOpenDir
+     * if it is open and removes backing source. Ignores errors.
+     *
+     * A new Temporary Directory will be created afterwards,
+     * so the worst case is leaving temporary directory (+files),
+     * but this is cleaned on reboot or manually by the user.
+     */
+    if (mOpenDir != NULL) {
+        mOpenDir->remove();
+        delete mOpenDir;
+        mOpenDir = NULL;
+    }
+}
+
+void ScanningSession::cloneToTemporaryFile(const QString& path)
+{
+    /*
+     * There are two situations when calling this function:
+     *
+     * 1) We've already opened a temporary file:
+     *      In this case, close and delete it, then:
+     * 2) We need to create a new temporary file:
+     *      Then we can copy data into it from path.
+     *
+     * By not closing and removing mOpenDir in closeFile()
+     * until openFile() is called, we prevent unintentional reloading
+     * of the real path. Further, calling fileOpen(...) with the same
+     * path results in reloading the file.
+     */
+
+    // Clean the temporary directory if it is open already, then create
+    // a new one.
+    cleanTmpDir();
+    mOpenDir = new QTemporaryDir();
+
+    // Recalling is unlikely to succeed, so throw a fatal exception
+    if (!mOpenDir->isValid())
+    {
+        throw std::runtime_error(mOpenDir->errorString().toUtf8().constData());
+    }
+
+    // XCCDF files can have relative includes; get a complete closure set
+    // of the opened file and validate that they all share a common
+    // ancestor which is the ancestor of the input path. Otherwise, this
+    // file cannot be opened without recreating excessive directory structure.
+    //
+    // Files which violate this constraint are rare; thus it should be safe
+    // to refuse to open them.
+    QSet<QString> closureOfFile;
+    getDependencyClosureOfFile(path, closureOfFile);
+
+    const QFileInfo pathInfo(path);
+    QString baseDirectory = pathInfo.absolutePath();
+    for (const QString& cur : closureOfFile)
+    {
+        // Since getDependencyClosureOfFile(...) returns cleaned absolute
+        // paths, we can check if the path starts with the baseDirectory
+        if (!cur.startsWith(baseDirectory))
+        {
+            throw std::runtime_error("Refusing to open XCCDF file because "
+                                     "closure of includes violate "
+                                     "directory constraints: common ancestor");
+        }
+    }
+
+    // File is valid; extract the new location and copy dependencies into
+    // their correct places.
+    QString tmpPath = mOpenDir->path() + QDir::separator();
+
+    // set mOpenPath to the new temporary location and copy it.
+    mOpenPath = tmpPath + pathInfo.fileName();
+    QFile::copy(path, mOpenPath);
+
+    QDir tmpDir(tmpPath);
+    for (const QString& cur : closureOfFile)
+    {
+        const QFileInfo curInfo(cur);
+        const QDir curDir = curInfo.absoluteDir();
+
+        if (curDir.absolutePath() != baseDirectory)
+        {
+            // Create subdirectories and copy into the new directory
+            //
+            // Since curPath is an absolute path, which has an eventual
+            // parent of baseDirectory, the left n = baseDirectory.length()+1
+            // characters are baseDirectory plus a trailing slash; the
+            // remaining characters to the right of this (curPath.length()-n)
+            // is the recursive directory structure of cur (e.g., all the
+            // subdirs it resides in). We can then plant this on tmpPath
+            // and use mkpath to recreate that directory structure. We ignore
+            // errors from mkpath because we might have previously created
+            // this path in a previous loop iteration.
+            const QString curPath = curDir.absolutePath();
+            const int pathLen = curPath.length() - baseDirectory.length() - 1;
+            const QString subDirs = curPath.right(pathLen);
+            const QString newPath = tmpPath + subDirs + QDir::separator() + curInfo.fileName();
+
+            tmpDir.mkpath(tmpPath + subDirs);
+            QFile::copy(cur, newPath);
+        }
+        else
+        {
+            // Simply copy the file since it resides in baseDirectory
+            QFile::copy(cur, tmpPath + curInfo.fileName());
+        }
+    }
+}
+
+void ScanningSession::openFile(const QString& path, bool reload)
 {
     if (mSession)
         closeFile();
 
-    const QFileInfo pathInfo(path);
+    if (reload || mOpenPath != path)
+    {
+        cloneToTemporaryFile(path);
+    }
+
+    const QString tmpPath = mOpenPath;
+    const QFileInfo pathInfo(mOpenPath);
 
     // We have to make sure that we *ALWAYS* open the session by absolute
     // path. oscap local won't be run from the same directory from where
@@ -120,7 +243,7 @@ QString ScanningSession::getOpenedFilePath() const
     return xccdf_session_get_filename(mSession);
 }
 
-inline void getDependencyClosureOfFile(const QString& filePath, QSet<QString>& targetSet)
+void ScanningSession::getDependencyClosureOfFile(const QString& filePath, QSet<QString>& targetSet) const
 {
     QFileInfo fileInfo(filePath);
     targetSet.insert(fileInfo.absoluteFilePath()); // insert current file
@@ -185,7 +308,7 @@ inline void getDependencyClosureOfFile(const QString& filePath, QSet<QString>& t
 QSet<QString> ScanningSession::getOpenedFilesClosure() const
 {
     QSet<QString> ret;
-    getDependencyClosureOfFile(getOpenedFilePath(), ret);
+    ScanningSession::getDependencyClosureOfFile(getOpenedFilePath(), ret);
     return ret;
 }
 

--- a/src/TemporaryDir.cpp
+++ b/src/TemporaryDir.cpp
@@ -36,7 +36,7 @@ static bool recursiveRemoveDir(const QString& dirName)
 
     if (dir.exists(dirName))
     {
-        Q_FOREACH(QFileInfo info, dir.entryInfoList(QDir::NoDotAndDotDot | QDir::System | QDir::Hidden  | QDir::AllDirs | QDir::Files, QDir::DirsFirst))
+        for (QFileInfo info : dir.entryInfoList(QDir::NoDotAndDotDot | QDir::System | QDir::Hidden  | QDir::AllDirs | QDir::Files, QDir::DirsFirst))
         {
             if (info.isDir())
                 result = recursiveRemoveDir(info.absoluteFilePath());

--- a/ui/MainWindow.ui
+++ b/ui/MainWindow.ui
@@ -566,7 +566,7 @@
      <x>0</x>
      <y>0</y>
      <width>800</width>
-     <height>29</height>
+     <height>26</height>
     </rect>
    </property>
    <property name="font">
@@ -590,6 +590,7 @@
     </widget>
     <addaction name="actionOpenSSG"/>
     <addaction name="actionOpen"/>
+    <addaction name="actionReloadContent"/>
     <addaction name="separator"/>
     <addaction name="actionOpenCustomizationFile"/>
     <addaction name="separator"/>
@@ -671,6 +672,17 @@
   <action name="actionOpenCustomizationFile">
    <property name="text">
     <string>Open &amp;Customization File</string>
+   </property>
+  </action>
+  <action name="actionReloadContent">
+   <property name="text">
+    <string>&amp;Reload Opened Content</string>
+   </property>
+   <property name="iconText">
+    <string>Reload Opened Content</string>
+   </property>
+   <property name="toolTip">
+    <string>Reload Opened Content</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
- Implements copying input + dependencies to a temporary directory
- Adds a reload opened content button to the UI (under File)
- Opens an information dialog when the file changes on disk (once)