### PR TITLE
pkexec: avoid potential local root exploit by using PKEXEC_UID and sudo

### DIFF
--- a/scap-workbench-pkexec-oscap.sh
+++ b/scap-workbench-pkexec-oscap.sh
@@ -18,9 +18,6 @@
 
 set -u -o pipefail
 
-uid=`id -u`
-gid=`id -g`
-
 PARENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 PKEXEC_PATH="pkexec"
@@ -29,7 +26,7 @@ SCAP_WORKBENCH_OSCAP="$PARENT_DIR/scap-workbench-oscap.sh"
 # We run unprivileged if pkexec was not found.
 #which $PKEXEC_PATH > /dev/null || exit 1 # fail if pkexec was not found
 
-$PKEXEC_PATH --disable-internal-agent "$SCAP_WORKBENCH_OSCAP" $uid $gid "$@" 2> >(tail -n +2 1>&2)
+$PKEXEC_PATH --disable-internal-agent "$SCAP_WORKBENCH_OSCAP" "$@" 2> >(tail -n +2 1>&2)
 EC=$?
 
 # 126 is a special exit code of pkexec when user dismisses the auth dialog
@@ -38,7 +35,7 @@ EC=$?
 # This is common in niche desktop environments.
 if [ $EC -eq 126 ] || [ $EC -eq 127 ]; then
     # in case of dismissed dialog we run without super user rights
-    "$SCAP_WORKBENCH_OSCAP" $uid $gid "$@" 2> >(tail -n +2 1>&2);
+    "$SCAP_WORKBENCH_OSCAP" "$@" 2> >(tail -n +2 1>&2);
     exit $?
 fi
 


### PR DESCRIPTION
If an admin relaxes the required polkit authentication for running
scap-workbench-oscap.sh from auth_admin to auth_self or yes, then the
current implementation of the wrapper script allows for a local root
exploit.

A command line like this would overwrite /etc/shadow with a file owned
by the non-privileged user:

pkexec --disable-internal-agent /usr/lib64/scap-workbench/scap-workbench-oscap.sh 1000 100 \
	xccdf eval --profile Default --oval-results --results /etc/shadow \
	--results-arf /tmp/scap.results.arf --report /tmp/scap.report \
	--progress /usr/share/openscap/scap-yast2sec-xccdf.xml

The copying of the target files needs to be done in the context of the
unprivileged user to prevent any symlink attacks or maliciously
specified paths. This is done by using sudo as a frontend to cp.

Also the user should not pass his own uid and gid. This would allow to
change ownership of files to arbitrary other users. Instead pkexec
offers the PKEXEC_UID environment variable which contains the uid of the
authenticated user. The gid can be derived from the uid.