### PR TITLE
Add OL7 support to SSGIntegrationDialog

### DIFF
--- a/src/SSGIntegrationDialog.cpp
+++ b/src/SSGIntegrationDialog.cpp
@@ -111,9 +111,9 @@ void SSGIntegrationDialog::scrapeSSGVariants()
 
         bool favorite = false;
         // Make the label nicer for known variants
-        if (label.startsWith("rhel"))
+        if (label.startsWith("rhel") || label.startsWith("ol"))
         {
-            // use RHEL instead of rhel
+            // use RHEL instead of rhel and OL instead of ol
             label = name.toUpper();
             favorite = true;
         }


### PR DESCRIPTION
#### Description

Add OL7 content to SSG integration dialog

#### Testing (Oracle Linux 7)
- Built scap-workbench package on top of master and installed on OL7
- Checked OL7 content available for selection and loads expected profiles

#### Notes
I couldn't find target branch policy for this merge, v1-2 selected by default. OL7.5 now uses scap-workbench-1.1.6 while it could be considered next update might switch to v1-2.  If possible and makes sense please merge this change in both v1-1 and v1-2 branches. Let me know if any change or additional PR required.

Signed-off-by: Ilya Okomin <ilya.okomin@oracle.com>