### PR TITLE
Update content repository in travis script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,8 @@ before_script:
 
 script:
   - ./build-for-osx.sh
-  - wget `curl -s https://api.github.com/repos/openscap/scap-security-guide/releases/latest?access_token=$GITHUB_TOKEN | jq -r ".assets[] | select(.name | test(\"(scap-security-guide-[0-9].[0-9].[0-9]*).zip\")) | .browser_download_url"` -O ssg.zip
+# Parse release page json to obtain link to latest content zip file and download it
+  - wget `curl -s https://api.github.com/repos/ComplianceAsCode/content/releases/latest?access_token=$GITHUB_TOKEN | jq -r ".assets[] | select(.name | test(\"(scap-security-guide-[0-9].[0-9].[0-9]*).zip\")) | .browser_download_url"` -O ssg.zip
   - mkdir -p `pwd`/scap-workbench.app/Contents/Resources/ssg/ && unzip ssg.zip -d `pwd`/scap-workbench.app/Contents/Resources/ssg/
   - cd build-osx && sh osx-create-dmg.sh
 


### PR DESCRIPTION
- SCAP Security Guide project changed its name and moved to a different organization.
- Update Travis CI yml to obtain content directly from `ComplianceAsCode`.

- Fixes build failures in travis:
  - https://travis-ci.org/OpenSCAP/scap-workbench/builds/416898892#L4343