### PR TITLE
Fix SCAP Workbench errors shown in Diagnostics Windows

### DIFF
--- a/scap-workbench-oscap.sh
+++ b/scap-workbench-oscap.sh
@@ -93,7 +93,7 @@ function chown_copy
 
     # chown only required if wrapper_{uid,gid} differs from real_{uid,gid}
     if [ $wrapper_uid -ne $real_uid ] || [ $wrapper_gid -ne $real_gid ]; then
-        chown $wrapper_uid:$wrapper_gid $where
+        chown $wrapper_uid:$wrapper_gid "$where"
     fi
 }
 


### PR DESCRIPTION
This patch addresses the follwong part of messages chunk. Even if it
says that "oscap" process has written the content, it's the wrapper
script in fact.

```
14:34:53 | error    | The 'oscap' process has written the following
content to stderr:
chown: cannot access '/tmp/SCAP': No such file or directory

14:34:53 | error    | The 'oscap' process has written the following
content to stderr:
chown: cannot access 'Workbench.h22666': No such file or directory

14:34:53 | error    | The 'oscap' process has written the following
content to stderr:
chown: cannot access '/tmp/SCAP': No such file or directory

14:34:53 | error    | The 'oscap' process has written the following
content to stderr:
chown: cannot access 'Workbench.M22666': No such file or directory

14:34:53 | error    | The 'oscap' process has written the following
content to stderr:
chown: cannot access '/tmp/SCAP': No such file or directory

14:34:53 | error    | The 'oscap' process has written the following
content to stderr:
chown: cannot access 'Workbench.X22666': No such file or directory
```