### PR TITLE
[v1-2] Fix results font color

### DIFF
--- a/ui/RuleResultItem.ui
+++ b/ui/RuleResultItem.ui
@@ -81,7 +81,7 @@
          <enum>Qt::NoContextMenu</enum>
         </property>
         <property name="styleSheet">
-         <string notr="true">text-align: left; border: 0; padding-left: 5px; </string>
+         <string notr="true">text-align: left; border: 0; padding-left: 5px;</string>
         </property>
         <property name="text">
          <string>Title</string>
@@ -122,8 +122,7 @@
    <item>
     <widget class="QLabel" name="description">
      <property name="styleSheet">
-      <string notr="true">margin-left: 25px;
-border: 1px solid #ddd;</string>
+      <string notr="true">margin-left: 25px; border: 1px solid #ddd; color: #000000;</string>
      </property>
      <property name="text">
       <string/>

--- a/ui/RuleResultsTree.ui
+++ b/ui/RuleResultsTree.ui
@@ -41,7 +41,7 @@
        <bool>false</bool>
       </property>
       <property name="styleSheet">
-       <string notr="true">background: white;</string>
+       <string notr="true">background: white; color: #000000;</string>
       </property>
      </widget>
     </widget>


### PR DESCRIPTION
- Sets the Rule title and description font color to black. The font became hard to read when using dark themes in Gnome