### PR TITLE
Do not set application name

### DIFF
--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -37,7 +37,6 @@ Application::Application(int& argc, char** argv):
     setOrganizationName("SCAP Workbench upstream");
     setOrganizationDomain("https://www.open-scap.org/tools/scap-workbench");
 
-    setApplicationName("SCAP Workbench");
     setApplicationVersion(SCAP_WORKBENCH_VERSION);
 
     mMainWindow = new MainWindow();


### PR DESCRIPTION
We use QTemporaryFile to create temporary files. According to
https://doc.qt.io/qt-5/qtemporaryfile.html, the default filename is
determined from QCoreApplication::applicationName(). It returns "SCAP
Workbench" which leads to creating temporary files with a space
character in their name, eg. "/tmp/SCAP Workbench.XM8663". The space can
cause problems with missing quotes s.a. the problems described in issue
application name manually. Hopefully it will not cause any problem.  If
not set, the application name defaults to the executable name, which is
`scap-workbench`. It doesn't affect the window title.