### PR TITLE
Stopped using deprecated escape static method.

### DIFF
--- a/src/APIHelpers.cpp
+++ b/src/APIHelpers.cpp
@@ -44,7 +44,7 @@ QString oscapItemGetReadableTitle(struct xccdf_item* item, struct xccdf_policy* 
     oscap_text_iterator_free(title_it);
     if (!unresolved)
         return "";
-    char* resolved = xccdf_policy_substitute(Qt::escape(QString::fromUtf8(unresolved)).toUtf8().constData(), policy);
+    char* resolved = xccdf_policy_substitute(QString::fromUtf8(unresolved).toHtmlEscaped().toUtf8().constData(), policy);
     free(unresolved);
     const QString ret = QString::fromUtf8(resolved);
     free(resolved);

--- a/src/DiagnosticsDialog.cpp
+++ b/src/DiagnosticsDialog.cpp
@@ -142,7 +142,7 @@ void DiagnosticsDialog::pushMessage(MessageSeverity severity, const QString& ful
     QString outputMessage = fullMessage;
     if (format & MF_XML)
     {
-        outputMessage = Qt::escape(outputMessage);
+        outputMessage = outputMessage.toHtmlEscaped();
     }
 
     if (format & MF_PREFORMATTED)


### PR DESCRIPTION
See also: https://wiki.qt.io/Transition_from_Qt_4.x_to_Qt5#Qt::escape_is_deprecated