### PR TITLE
Make the message concerning unused values in a rule precise.

### DIFF
--- a/src/TailoringDockWidgets.cpp
+++ b/src/TailoringDockWidgets.cpp
@@ -253,7 +253,9 @@ void XCCDFItemPropertiesDockWidget::refresh()
                 }
                 html += "</ul>\n";
 
-                mUI.affectsRulesBrowser->setHtml(empty ? "This value doesn't seem to be affecting any rules!" : html);
+		// The variable-rules map is constructed in a generateValueAffectsRulesMap method
+		// that only uses checks as input data.
+                mUI.affectsRulesBrowser->setHtml(empty ? "This value doesn't seem to be used in any rule's check." : html);
             }
 
             mUI.affectsRulesLabel->show();


### PR DESCRIPTION
The previous message suggested that the value is not used anywhere, but in fact the input data only includes checks.