### PR TITLE
Fixed integration dialog sizing

### DIFF
--- a/ui/SSGIntegrationDialog.ui
+++ b/ui/SSGIntegrationDialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>889</width>
-    <height>288</height>
+    <height>330</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -28,6 +28,9 @@
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout_3">
+     <property name="spacing">
+      <number>12</number>
+     </property>
      <item>
       <widget class="QLabel" name="ssgLogo">
        <property name="sizePolicy">
@@ -52,15 +55,19 @@
      </item>
      <item>
       <layout class="QVBoxLayout" name="verticalLayout_3">
+       <property name="sizeConstraint">
+        <enum>QLayout::SetMinimumSize</enum>
+       </property>
        <property name="leftMargin">
         <number>0</number>
        </property>
        <item>
         <widget class="QLabel" name="label">
-         <property name="font">
-          <font>
-           <pointsize>11</pointsize>
-          </font>
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
          </property>
          <property name="text">
           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;SCAP Security Guide was found installed on this machine.&lt;/p&gt;&lt;p&gt;The content provided by SCAP Security Guide allows you to quickly scan your machine according to well stablished security baselines.&lt;/p&gt;&lt;p&gt;Also, these guides are a good starting point if you'd like to customize a policy or profile for your own needs.&lt;/p&gt;&lt;p&gt;Select one of the default guides to load, or select Other SCAP Content option to load your own content.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
@@ -111,10 +118,13 @@
          <property name="orientation">
           <enum>Qt::Vertical</enum>
          </property>
+         <property name="sizeType">
+          <enum>QSizePolicy::MinimumExpanding</enum>
+         </property>
          <property name="sizeHint" stdset="0">
           <size>
            <width>20</width>
-           <height>40</height>
+           <height>20</height>
           </size>
          </property>
         </spacer>
@@ -156,24 +166,6 @@
       </layout>
      </item>
     </layout>
-   </item>
-   <item>
-    <widget class="QWidget" name="widget" native="true">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <layout class="QHBoxLayout" name="horizontalLayout">
-      <property name="spacing">
-       <number>6</number>
-      </property>
-      <property name="margin">
-       <number>0</number>
-      </property>
-     </layout>
-    </widget>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
Before, the dialog/label size was given by static values. This PR makes the dialog to resize depending on the text length, which should be more robust.

- Made the label height auto-adjustable - see https://stackoverflow.com/a/19294869
- Increased horizontal spacing between logo / label
- Removed a "widget" that isn't used, and messed up the layout
- Decreased the default dialog height, that acts as a minimal height.

Fixes: rhbz#1743713