### PR TITLE
Generate result-based remediation from tailored profile

### DIFF
--- a/include/RemediationRoleSaver.h
+++ b/include/RemediationRoleSaver.h
@@ -98,33 +98,35 @@ class PuppetProfileRemediationSaver : public ProfileBasedRemediationSaver
 class ResultBasedProcessRemediationSaver : public RemediationSaverBase
 {
     public:
-        ResultBasedProcessRemediationSaver(QWidget* parentWindow, const QByteArray& arfContents,
+        ResultBasedProcessRemediationSaver(
+                QWidget* parentWindow, const QByteArray& arfContents, const QString& tailoringFilePath,
                 const QString& saveMessage, const QString& filetypeExtension, const QString& filetypeTemplate, const QString& fixType);
 
     private:
         virtual void saveToFile(const QString& filename);
         SpacelessQTemporaryFile mArfFile;
+        QString tailoring;
 };
 
 
 class BashResultRemediationSaver : public ResultBasedProcessRemediationSaver
 {
     public:
-        BashResultRemediationSaver(QWidget* parentWindow, const QByteArray& arfContents);
+        BashResultRemediationSaver(QWidget* parentWindow, const QByteArray& arfContents, const QString& tailoringFilePath);
 };
 
 
 class AnsibleResultRemediationSaver : public ResultBasedProcessRemediationSaver
 {
     public:
-        AnsibleResultRemediationSaver(QWidget* parentWindow, const QByteArray& arfContents);
+        AnsibleResultRemediationSaver(QWidget* parentWindow, const QByteArray& arfContents, const QString& tailoringFilePath);
 };
 
 
 class PuppetResultRemediationSaver : public ResultBasedProcessRemediationSaver
 {
     public:
-        PuppetResultRemediationSaver(QWidget* parentWindow, const QByteArray& arfContents);
+        PuppetResultRemediationSaver(QWidget* parentWindow, const QByteArray& arfContents, const QString& tailoringFilePath);
 };
 
 #else  // i.e. SCAP_WORKBENCH_USE_LIBRARY_FOR_RESULT_BASED_REMEDIATION_ROLES_GENERATION is defined
@@ -133,33 +135,34 @@ class PuppetResultRemediationSaver : public ResultBasedProcessRemediationSaver
 class ResultBasedLibraryRemediationSaver : public RemediationSaverBase
 {
     public:
-        ResultBasedLibraryRemediationSaver(QWidget* parentWindow, const QByteArray& arfContents,
+        ResultBasedLibraryRemediationSaver(QWidget* parentWindow, const QByteArray& arfContents, const QString& tailoringFilePath,
                 const QString& saveMessage, const QString& filetypeExtension, const QString& filetypeTemplate, const QString& fixType);
 
     private:
         virtual void saveToFile(const QString& filename);
         SpacelessQTemporaryFile mArfFile;
+        QString tailoring;
 };
 
 
 class BashResultRemediationSaver : public ResultBasedLibraryRemediationSaver
 {
     public:
-        BashResultRemediationSaver(QWidget* parentWindow, const QByteArray& arfContents);
+        BashResultRemediationSaver(QWidget* parentWindow, const QByteArray& arfContents, const QString& tailoringFilePath);
 };
 
 
 class AnsibleResultRemediationSaver : public ResultBasedLibraryRemediationSaver
 {
     public:
-        AnsibleResultRemediationSaver(QWidget* parentWindow, const QByteArray& arfContents);
+        AnsibleResultRemediationSaver(QWidget* parentWindow, const QByteArray& arfContents, const QString& tailoringFilePath);
 };
 
 
 class PuppetResultRemediationSaver : public ResultBasedLibraryRemediationSaver
 {
     public:
-        PuppetResultRemediationSaver(QWidget* parentWindow, const QByteArray& arfContents);
+        PuppetResultRemediationSaver(QWidget* parentWindow, const QByteArray& arfContents, const QString& tailoringFilePath);
 };
 
 #endif  // SCAP_WORKBENCH_USE_LIBRARY_FOR_RESULT_BASED_REMEDIATION_ROLES_GENERATION

--- a/include/ResultViewer.h
+++ b/include/ResultViewer.h
@@ -99,6 +99,8 @@ class ResultViewer : public QWidget
         /// If user requests to open the file via desktop services
         SpacelessQTemporaryFile* mReportFile;
         QByteArray mARF;
+
+        QString tailoringFilePath;
 };
 
 #endif

--- a/src/RemediationRoleSaver.cpp
+++ b/src/RemediationRoleSaver.cpp
@@ -164,7 +164,8 @@ PuppetProfileRemediationSaver::PuppetProfileRemediationSaver(QWidget* parentWind
 {}
 
 #ifndef SCAP_WORKBENCH_USE_LIBRARY_FOR_RESULT_BASED_REMEDIATION_ROLES_GENERATION
-ResultBasedProcessRemediationSaver::ResultBasedProcessRemediationSaver(QWidget* parentWindow, const QByteArray& arfContents,
+ResultBasedProcessRemediationSaver::ResultBasedProcessRemediationSaver(
+        QWidget* parentWindow, const QByteArray& arfContents, const QString& tailoringFilePath,
         const QString& saveMessage, const QString& filetypeExtension, const QString& filetypeTemplate, const QString& fixType):
     RemediationSaverBase(parentWindow, saveMessage, filetypeExtension, filetypeTemplate, fixType)
 {
@@ -172,6 +173,7 @@ ResultBasedProcessRemediationSaver::ResultBasedProcessRemediationSaver(QWidget* 
     mArfFile.open();
     mArfFile.write(arfContents);
     mArfFile.close();
+    tailoring = tailoringFilePath;
 }
 
 void ResultBasedProcessRemediationSaver::saveToFile(const QString& filename)
@@ -190,6 +192,11 @@ void ResultBasedProcessRemediationSaver::saveToFile(const QString& filename)
     // However, ommitting --result-id "" won't work.
     args.append("--result-id");
     args.append("");
+
+    if (!tailoring.isNull()) {
+        args.append("--tailoring-file");
+        args.append(tailoring.toUtf8().constData());
+    }
 
     args.append(mArfFile.fileName());
 
@@ -222,23 +229,24 @@ void ResultBasedProcessRemediationSaver::saveToFile(const QString& filename)
     }
 }
 
-BashResultRemediationSaver::BashResultRemediationSaver(QWidget* parentWindow, const QByteArray& arfContents):
-    ResultBasedProcessRemediationSaver(parentWindow, arfContents,
+BashResultRemediationSaver::BashResultRemediationSaver(QWidget* parentWindow, const QByteArray& arfContents, const QString& tailoringFilePath):
+    ResultBasedProcessRemediationSaver(parentWindow, arfContents, tailoringFilePath,
             bashSaveMessage, bashFiletypeExtension, bashFiletypeTemplate, bashFixTemplate)
 {}
 
-AnsibleResultRemediationSaver::AnsibleResultRemediationSaver(QWidget* parentWindow, const QByteArray& arfContents):
-    ResultBasedProcessRemediationSaver(parentWindow, arfContents,
+AnsibleResultRemediationSaver::AnsibleResultRemediationSaver(QWidget* parentWindow, const QByteArray& arfContents, const QString& tailoringFilePath):
+    ResultBasedProcessRemediationSaver(parentWindow, arfContents, tailoringFilePath,
             ansibleSaveMessage, ansibleFiletypeExtension, ansibleFiletypeTemplate, ansibleFixType)
 {}
 
-PuppetResultRemediationSaver::PuppetResultRemediationSaver(QWidget* parentWindow, const QByteArray& arfContents):
-    ResultBasedProcessRemediationSaver(parentWindow, arfContents,
+PuppetResultRemediationSaver::PuppetResultRemediationSaver(QWidget* parentWindow, const QByteArray& arfContents, const QString& tailoringFilePath):
+    ResultBasedProcessRemediationSaver(parentWindow, arfContents, tailoringFilePath,
             puppetSaveMessage, puppetFiletypeExtension, puppetFiletypeTemplate, puppetFixType)
 {}
 
 #else  // i.e. SCAP_WORKBENCH_USE_LIBRARY_FOR_RESULT_BASED_REMEDIATION_ROLES_GENERATION is defined
-ResultBasedLibraryRemediationSaver::ResultBasedLibraryRemediationSaver(QWidget* parentWindow, const QByteArray& arfContents,
+ResultBasedLibraryRemediationSaver::ResultBasedLibraryRemediationSaver(
+        QWidget* parentWindow, const QByteArray& arfContents, const QString& tailoringFilePath,
         const QString& saveMessage, const QString& filetypeExtension, const QString& filetypeTemplate, const QString& fixType):
     RemediationSaverBase(parentWindow, saveMessage, filetypeExtension, filetypeTemplate, fixType)
 {
@@ -246,6 +254,7 @@ ResultBasedLibraryRemediationSaver::ResultBasedLibraryRemediationSaver(QWidget* 
     mArfFile.open();
     mArfFile.write(arfContents);
     mArfFile.close();
+    tailoring = tailoringFilePath;
 }
 
 void ResultBasedLibraryRemediationSaver::saveToFile(const QString& filename)
@@ -282,6 +291,9 @@ void ResultBasedLibraryRemediationSaver::saveToFile(const QString& filename)
 
     if (session == NULL)
         throw std::runtime_error("Couldn't get XCCDF session from the report source");
+    if (!tailoring.isNull()) {
+        xccdf_session_set_user_tailoring_file(session, tailoring.toUtf8().constData());
+    }
 
     xccdf_session_set_loading_flags(session, XCCDF_SESSION_LOAD_XCCDF);
     if (xccdf_session_load(session) != 0)
@@ -316,18 +328,18 @@ void ResultBasedLibraryRemediationSaver::saveToFile(const QString& filename)
     }
 }
 
-BashResultRemediationSaver::BashResultRemediationSaver(QWidget* parentWindow, const QByteArray& arfContents):
-    ResultBasedLibraryRemediationSaver(parentWindow, arfContents,
+BashResultRemediationSaver::BashResultRemediationSaver(QWidget* parentWindow, const QByteArray& arfContents, const QString& tailoringFilePath):
+    ResultBasedLibraryRemediationSaver(parentWindow, arfContents, tailoringFilePath,
             bashSaveMessage, bashFiletypeExtension, bashFiletypeTemplate, bashFixTemplate)
 {}
 
-AnsibleResultRemediationSaver::AnsibleResultRemediationSaver(QWidget* parentWindow, const QByteArray& arfContents):
-    ResultBasedLibraryRemediationSaver(parentWindow, arfContents,
+AnsibleResultRemediationSaver::AnsibleResultRemediationSaver(QWidget* parentWindow, const QByteArray& arfContents, const QString& tailoringFilePath):
+    ResultBasedLibraryRemediationSaver(parentWindow, arfContents, tailoringFilePath,
             ansibleSaveMessage, ansibleFiletypeExtension, ansibleFiletypeTemplate, ansibleFixType)
 {}
 
-PuppetResultRemediationSaver::PuppetResultRemediationSaver(QWidget* parentWindow, const QByteArray& arfContents):
-    ResultBasedLibraryRemediationSaver(parentWindow, arfContents,
+PuppetResultRemediationSaver::PuppetResultRemediationSaver(QWidget* parentWindow, const QByteArray& arfContents, const QString& tailoringFilePath):
+    ResultBasedLibraryRemediationSaver(parentWindow, arfContents, tailoringFilePath,
             puppetSaveMessage, puppetFiletypeExtension, puppetFiletypeTemplate, puppetFixType)
 {}
 

--- a/src/ResultViewer.cpp
+++ b/src/ResultViewer.cpp
@@ -114,6 +114,9 @@ void ResultViewer::loadContent(Scanner* scanner)
         if (mInputBaseName.endsWith("-xccdf"))
             mInputBaseName.chop(QString("-xccdf").length());
     }
+    if (session->isSelectedProfileTailoring()) {
+        tailoringFilePath = session->getTailoringFilePath();
+    }
 
     mReport.clear();
     scanner->getReport(mReport);
@@ -173,19 +176,19 @@ void ResultViewer::openReport()
 
 void ResultViewer::generateBashRemediationRole()
 {
-    BashResultRemediationSaver remediation(this, mARF);
+    BashResultRemediationSaver remediation(this, mARF, tailoringFilePath);
     remediation.selectFilenameAndSaveRole();
 }
 
 void ResultViewer::generateAnsibleRemediationRole()
 {
-    AnsibleResultRemediationSaver remediation(this, mARF);
+    AnsibleResultRemediationSaver remediation(this, mARF, tailoringFilePath);
     remediation.selectFilenameAndSaveRole();
 }
 
 void ResultViewer::generatePuppetRemediationRole()
 {
-    PuppetResultRemediationSaver remediation(this, mARF);
+    PuppetResultRemediationSaver remediation(this, mARF, tailoringFilePath);
     remediation.selectFilenameAndSaveRole();
 }
 


### PR DESCRIPTION
Users can generate remediation script from scan results
of a tailored profile.

Unfortunately, the current design of SCAP Workbench doesn't allow
a clear way of doing this. The scan is run in a separated oscap
process. SCAP Workbench doesn't have access to oscap internal
xccdf_session which creates the ARF. It can't obtain the Tailoring
component reference ID.

Instead, we will save the tailoring document to a temporary file
and use the temporary file when generating the remediation.

Resolves: RHBZ#1640715