### PR TITLE
Use QT provided macro function to version check - deprecation errors

### DIFF
--- a/src/SaveAsRPMDialog.cpp
+++ b/src/SaveAsRPMDialog.cpp
@@ -86,7 +86,12 @@ void SaveAsRPMDialog::slotFinished(int result)
     closure.remove(mScanningSession->getOpenedFilePath());
     QList<QString> closureOrdered;
     closureOrdered.append(mScanningSession->getOpenedFilePath());
-    closureOrdered.append(closure.toList());
+    #if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+        closureOrdered.append(closure.values());
+    #else
+        // support older versions where deprecation warning is not fatal
+        closureOrdered.append(closure.toList());
+    #endif
 
     const QDir cwd = ScanningSession::getCommonAncestorDirectory(closure);
 

--- a/src/TailoringWindow.cpp
+++ b/src/TailoringWindow.cpp
@@ -645,7 +645,12 @@ QString TailoringWindow::getQSettingsKey() const
 void TailoringWindow::deserializeCollapsedItems()
 {
     const QStringList list = mQSettings->value(getQSettingsKey()).toStringList();
-    mCollapsedItemIds = QSet<QString>::fromList(list);
+    #if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+        mCollapsedItemIds = QSet<QString>(list.begin(), list.end());
+    #else
+        // support older versions where deprecation warning is not fatal
+        mCollapsedItemIds = QSet<QString>::fromList(list);
+    #endif
 }
 
 void TailoringWindow::serializeCollapsedItems()
@@ -657,7 +662,12 @@ void TailoringWindow::serializeCollapsedItems()
     }
     else
     {
-        mQSettings->setValue(getQSettingsKey(), QVariant(mCollapsedItemIds.toList()));
+        #if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+            mQSettings->setValue(getQSettingsKey(), QVariant(mCollapsedItemIds.values()));
+        #else
+            // support older versions where deprecation warning is not fatal
+            mQSettings->setValue(getQSettingsKey(), QVariant(mCollapsedItemIds.toList()));
+        #endif
         mQSettings->setValue(getQSettingsKey() + "_lastUsed", QVariant(QDateTime::currentDateTime()));
     }
 }


### PR DESCRIPTION
This allows us to prevent fatal deprecation warnings from qt 5.13 to 5.14. This is also needed to support new CI pipelines that will be using the latest qt5.14.2+.