### PR TITLE
Update list of required packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ How to run it out of the box
 
 required dependencies:
 ```console
-# yum install cmake gcc-c++ openssh-clients util-linux openscap-devel qt5-devel openssh-askpass
+# yum install cmake gcc-c++ openssh-clients util-linux openscap-devel qt5-qtbase-devel qt5-qtxmlpatterns-devel openssh-askpass
 ```
 
 required dependencies (only for the git repo, not required for released tarballs):


### PR DESCRIPTION
qt5-devel is only a meta package. The real dependencies are qt5-qtbase-devel and qt5-qtxmlpatterns-devel. qt5-devel is
removed in Fedora 33. See https://lists.fedoraproject.org/archives/list/devel@lists.fedoraproject.org/message/WO625MVYEAAJNHNRLEEJDVZTIWMQOBRR/