### PR TITLE
Replace obsolete QString::SkipEmptyParts

### DIFF
--- a/src/OscapCapabilities.cpp
+++ b/src/OscapCapabilities.cpp
@@ -86,7 +86,11 @@ void OscapCapabilities::parse(const QString& mmv)
     if (lines.size() < 1)
         return; // TODO: Throw exception?
 
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 15, 0))
+    const QStringList firstLine = lines[0].split(' ', Qt::SkipEmptyParts);
+#else
     const QStringList firstLine = lines[0].split(' ', QString::SkipEmptyParts);
+#endif
     const QString& versionCandidate = firstLine.last();
 
     if (!versionCandidate.contains(QRegExp("^([0-9]+\\.){2,}[0-9]+$")))

--- a/src/RPMOpenHelper.cpp
+++ b/src/RPMOpenHelper.cpp
@@ -54,7 +54,11 @@ RPMOpenHelper::RPMOpenHelper(const QString& path)
         static QRegExp tailoringRE("^\\.\\/usr\\/share\\/xml\\/scap\\/[^\\/]+\\/tailoring-xccdf\\.xml+$");
         static QRegExp inputRE("^\\.\\/usr\\/share\\/xml\\/scap\\/[^\\/]+\\/[^\\/]+\\-(xccdf|ds)\\.xml+$");
 
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 15, 0))
+        QStringList lines = proc.getStdErrContents().split('\n', Qt::SkipEmptyParts);
+#else
         QStringList lines = proc.getStdErrContents().split('\n', QString::SkipEmptyParts);
+#endif
         for (QStringList::const_iterator it = lines.constBegin(); it != lines.constEnd(); ++it)
         {
             const QString& line = *it;


### PR DESCRIPTION
Starting from Qt 5.15, the enum QString::SplitBehavior is obsolete
and Qt::SplitBehavior should be used instead.
See:
https://doc.qt.io/qt-5.15/qstring-obsolete.html#SplitBehavior-enum
https://doc.qt.io/qt-5/qt.html#SplitBehaviorFlags-enum