### PR TITLE
Removed the app org domain definition.

### DIFF
--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -35,9 +35,12 @@ Application::Application(int& argc, char** argv):
     mMainWindow(0)
 {
     setOrganizationName("SCAP Workbench upstream");
-    setOrganizationDomain("https://www.open-scap.org/tools/scap-workbench");
+    // The org domain messes up the app title in the Gnome top bar.
+    // Other QT apps s.a. Wireshark, QT Creator don't specify the domain.
+    // setOrganizationDomain("open-scap.org");
 
     setApplicationName("SCAP Workbench");
+    setApplicationDisplayName("SCAP Workbench");
     setApplicationVersion(SCAP_WORKBENCH_VERSION);
 
     mMainWindow = new MainWindow();


### PR DESCRIPTION
The org domain messes up the app title in the Gnome top bar. That doesn't happen on RHEL<=8, but it occurs on Fedora>=32. Other QT apps s.a. Wireshark and QT Creator don't specify the domain, so I think that the domain is not meant to be used by desktop applications, although it is not documented in this way.

Also, a domain is not the same thing as website URL, so I have changed that invocation as well. As a result, the app title was messed up a bit less, but it was still messed up.