### PR TITLE
Implement possibility to scan by sudoers.

### DIFF
--- a/doc/user_manual.adoc
+++ b/doc/user_manual.adoc
@@ -363,6 +363,17 @@ files are not supported yet!
 .Selecting a remote machine for scanning
 image::scanning_remote_machine.png[align="center"]
 
+The remote user doesn't have to be a superuser - you can setup the remote
+`/etc/sudoers` file (using `visudo`) to enable the paswordless sudo for that particular user,
+and you check the "user is sudoer" checkbox.
+
+For example, if the scanning user is `oscap-user`, that would involve putting
+
+   oscap-user ALL=(root) NOPASSWD: /usr/bin/oscap xccdf eval *
+
+user specification into the `sudoers` file, or into a separate file
+that is included by `sudoers` s.a. `/etc/sudoers.d/99-oscap-user`.
+
 === Enable Online Remediation (optional)
 
 ****

--- a/include/OscapScannerRemoteSsh.h
+++ b/include/OscapScannerRemoteSsh.h
@@ -36,6 +36,7 @@ class OscapScannerRemoteSsh : public OscapScannerBase
         OscapScannerRemoteSsh();
         virtual ~OscapScannerRemoteSsh();
 
+        void setUserIsSudoer(bool userIsSudoer);
         virtual void setTarget(const QString& target);
         virtual void setSession(ScanningSession* session);
 
@@ -57,6 +58,7 @@ class OscapScannerRemoteSsh : public OscapScannerBase
         void removeRemoteDirectory(const QString& path, const QString& desc);
 
         SshConnection mSshConnection;
+        bool mUserIsSudoer;
 };
 
 #endif

--- a/include/OscapScannerRemoteSsh.h
+++ b/include/OscapScannerRemoteSsh.h
@@ -43,6 +43,11 @@ class OscapScannerRemoteSsh : public OscapScannerBase
         virtual QStringList getCommandLineArgs() const;
         virtual void evaluate();
 
+    protected:
+
+       virtual void selectError(MessageType& kind, const QString& message);
+       virtual void processError(QString& message);
+
     private:
         void ensureConnected();
 

--- a/include/OscapScannerRemoteSsh.h
+++ b/include/OscapScannerRemoteSsh.h
@@ -31,11 +31,12 @@ class OscapScannerRemoteSsh : public OscapScannerBase
     Q_OBJECT
 
     public:
-        static void splitTarget(const QString& in, QString& target, unsigned short& port);
+        static void splitTarget(const QString& in, QString& target, unsigned short& port, bool& userIsSudoer);
 
         OscapScannerRemoteSsh();
         virtual ~OscapScannerRemoteSsh();
 
+        bool getUserIsSudoer() const;
         void setUserIsSudoer(bool userIsSudoer);
         virtual void setTarget(const QString& target);
         virtual void setSession(ScanningSession* session);

--- a/include/RemoteMachineComboBox.h
+++ b/include/RemoteMachineComboBox.h
@@ -44,6 +44,7 @@ class RemoteMachineComboBox : public QWidget
 
         void setRecentMachineCount(unsigned int count);
         unsigned int getRecentMachineCount() const;
+        bool userIsSudoer() const;
 
     public slots:
         void notifyTargetUsed(const QString& target);
@@ -65,6 +66,7 @@ class RemoteMachineComboBox : public QWidget
 
         QStringList mRecentTargets;
         QComboBox* mRecentComboBox;
+        QCheckBox* mUserIsSudoer;
 };
 
 #endif

--- a/include/RemoteMachineComboBox.h
+++ b/include/RemoteMachineComboBox.h
@@ -47,7 +47,7 @@ class RemoteMachineComboBox : public QWidget
         bool userIsSudoer() const;
 
     public slots:
-        void notifyTargetUsed(const QString& target);
+        void notifyTargetUsed(const QString& target, bool userIsSudoer);
         void clearHistory();
 
     protected slots:

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -763,7 +763,10 @@ void MainWindow::scanAsync(ScannerMode scannerMode)
     );
 
     if (target != "localhost")
-        mUI.remoteMachineDetails->notifyTargetUsed(mScanner->getTarget());
+    {
+        bool userIsSudoer = ((OscapScannerRemoteSsh *)mScanner)->getUserIsSudoer();
+        mUI.remoteMachineDetails->notifyTargetUsed(mScanner->getTarget(), userIsSudoer);
+    }
 
     mScanThread->start();
 }

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -678,6 +678,7 @@ void MainWindow::scanAsync(ScannerMode scannerMode)
     // In the OscapScannerRemoteSsh class the port will be parsed out again...
     const QString target = mUI.localMachineRadioButton->isChecked() ?
         "localhost" : mUI.remoteMachineDetails->getTarget();
+    const bool userIsSudoer = mUI.remoteMachineDetails->userIsSudoer();
 
     bool fetchRemoteResources = mUI.fetchRemoteResourcesCheckbox->isChecked();
     try
@@ -689,7 +690,10 @@ void MainWindow::scanAsync(ScannerMode scannerMode)
             if (target == "localhost")
                 mScanner = new OscapScannerLocal();
             else
+            {
                 mScanner = new OscapScannerRemoteSsh();
+                ((OscapScannerRemoteSsh *)mScanner)->setUserIsSudoer(userIsSudoer);
+            }
 
             mScanner->setTarget(target);
 

--- a/src/OscapScannerRemoteSsh.cpp
+++ b/src/OscapScannerRemoteSsh.cpp
@@ -344,6 +344,29 @@ void OscapScannerRemoteSsh::evaluate()
     signalCompletion(mCancelRequested);
 }
 
+void OscapScannerRemoteSsh::selectError(MessageType& kind, const QString& message)
+{
+    OscapScannerBase::selectError(kind, message);
+    if (mUserIsSudoer)
+    {
+        if (message.contains(QRegExp("^sudo:")))
+        {
+            kind = MSG_ERROR;
+        }
+    }
+
+}
+
+void OscapScannerRemoteSsh::processError(QString& message)
+{
+    OscapScannerBase::processError(message);
+    if (mUserIsSudoer && message.contains(QRegExp("^sudo:")))
+    {
+        message.replace(QRegExp("^sudo:"), "Error invoking sudo on the host:");
+        message += ".\nOnly passwordless sudo setup on the remote host is supported by scap-workbench.";
+    }
+}
+
 void OscapScannerRemoteSsh::ensureConnected()
 {
     if (mSshConnection.isConnected())

--- a/src/OscapScannerRemoteSsh.cpp
+++ b/src/OscapScannerRemoteSsh.cpp
@@ -364,6 +364,8 @@ void OscapScannerRemoteSsh::processError(QString& message)
     {
         message.replace(QRegExp("^sudo:"), "Error invoking sudo on the host:");
         message += ".\nOnly passwordless sudo setup on the remote host is supported by scap-workbench.";
+        message += " \nTo configure a non-privileged user oscap-user to run only the oscap binary as root, "
+		"add this User Specification to your sudoers file: oscap-user ALL=(root) NOPASSWD: /usr/bin/oscap xccdf eval *";
     }
 }
 

--- a/src/RemoteMachineComboBox.cpp
+++ b/src/RemoteMachineComboBox.cpp
@@ -41,6 +41,8 @@ RemoteMachineComboBox::RemoteMachineComboBox(QWidget* parent):
         this, SLOT(updateHostPort(int))
     );
 
+    mUserIsSudoer = mUI.userIsSudoer;
+
     setRecentMachineCount(5);
     syncFromQSettings();
 
@@ -49,6 +51,11 @@ RemoteMachineComboBox::RemoteMachineComboBox(QWidget* parent):
 RemoteMachineComboBox::~RemoteMachineComboBox()
 {
     delete mQSettings;
+}
+
+bool RemoteMachineComboBox::userIsSudoer() const
+{
+    return mUserIsSudoer->isChecked();
 }
 
 QString RemoteMachineComboBox::getTarget() const

--- a/ui/RemoteMachineComboBox.ui
+++ b/ui/RemoteMachineComboBox.ui
@@ -6,15 +6,24 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>553</width>
-    <height>29</height>
+    <width>609</width>
+    <height>42</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>RemoteMachineComboBox</string>
   </property>
   <layout class="QHBoxLayout" name="horizontalLayout">
-   <property name="margin">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
     <number>0</number>
    </property>
    <item>
@@ -73,8 +82,17 @@
    </item>
    <item>
     <widget class="QSpinBox" name="port">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="buttonSymbols">
-      <enum>QAbstractSpinBox::UpDownArrows</enum>
+      <enum>QAbstractSpinBox::NoButtons</enum>
      </property>
      <property name="minimum">
       <number>1</number>
@@ -84,6 +102,16 @@
      </property>
      <property name="value">
       <number>22</number>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="userIsSudoer">
+     <property name="toolTip">
+      <string>Check if the remote user doesn't have root privileges, but they can perform administrative tasks using paswordless sudo.</string>
+     </property>
+     <property name="text">
+      <string>user is sudoer</string>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
- The remote scanning dialog got a "user is sudoer" checkbox.
- Dry run can make use of sudo in connection with `oscap-ssh`.
- The scanning procedure uses sudo invocation as part of the `ssh` command.

This PR depends on #271 as it makes use of advanced message filtering.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1877522