### PR TITLE
Add Ubuntu dependency instructions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,4 +63,3 @@ jobs:
         files: build-osx/scap-workbench-${{ steps.get_version.outputs.VERSION }}.dmg
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -1,0 +1,23 @@
+name: OpenScap Workbench CI
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on: [push, pull_request]
+
+jobs:
+  build-ubuntu:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install required dependencies
+      run: |
+        sudo apt install -y build-essential openssh-client libopenscap-dev
+        sudo apt install -y libqt5xmlpatterns5-dev ssh-askpass asciidoc
+        sudo apt install -y libpolkit-agent-1-0
+    - name: Build SCAP Workbench
+      run: |
+        mkdir -p build
+        pushd build
+        cmake ..
+        make
+        popd

--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@ optional dependencies:
 # yum install polkit
 ```
 
+On Ubuntu this is roughly equivalent to:
+
+```console
+# apt install build-essential openssh-client libopenscap-dev libqt5xmlpatterns5-dev ssh-askpass
+# apt install asciidoc
+# apt install libpolkit-agent-1-0
+```
+
 2) Build SCAP Workbench:
 ```console
 $ mkdir build; cd build


### PR DESCRIPTION
`Signed-off-by: Alexander Scheel <alex.scheel@canonical.com>`

---

Starting slow again :-) 


Do we want to drop the `master` branch and recreate it from current `v1-2` branch (or later create a `v1-3` branch instead)?

I haven't yet checked with the current Debian maintainers to see if they're still interested in packaging `scap-workbench`. It was last present in Buster, at an earlier v1.1 version. That means it was last in 18.04 and hasn't been present since.

Is anyone here in contact with them by any chance?