### PR TITLE
Fix potential NULL pointer dereference

### DIFF
--- a/src/ResultViewer.cpp
+++ b/src/ResultViewer.cpp
@@ -113,9 +113,10 @@ void ResultViewer::loadContent(Scanner* scanner)
 
         if (mInputBaseName.endsWith("-xccdf"))
             mInputBaseName.chop(QString("-xccdf").length());
-    }
-    if (session->isSelectedProfileTailoring()) {
-        tailoringFilePath = session->getTailoringFilePath();
+
+        if (session->isSelectedProfileTailoring()) {
+            tailoringFilePath = session->getTailoringFilePath();
+        }
     }
 
     mReport.clear();


### PR DESCRIPTION
With the async behavior of Scanner (and its interactions in MainWindow),
it isn't obvious that Session can't be non-`NULL` here. Hence it is
probably better to move the session use into the if-guard.

Resolves: #262

`Signed-off-by: Alexander Scheel <alexander.m.scheel@gmail.com>`

---

Looks like @mpreisler originally wrote the if-guard but didn't mention why it was necessary either :-) 