### PR TITLE
Use reference to avoid range-loop-construct diagnostic

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -409,7 +409,7 @@ void MainWindow::openFile(const QString& path, bool reload)
 
         // Refill mFSWatch after opening file
         mFSWatch->removePaths(mFSWatch->files());
-        for (const QString path : mScanningSession->getOriginalClosure())
+        for (const QString &path : mScanningSession->getOriginalClosure())
         {
             mFSWatch->addPath(path);
         }


### PR DESCRIPTION
Pulled from scap-workbench-1.2.1-7 in Fedora Rawhide.

`Signed-off-by: Alexander Scheel <alex.scheel@canonical.com>`