### PR TITLE
Allow profile description customization

### DIFF
--- a/ui/ProfilePropertiesDockWidget.ui
+++ b/ui/ProfilePropertiesDockWidget.ui
@@ -21,7 +21,16 @@
   </property>
   <widget class="QWidget" name="dockWidgetContents">
    <layout class="QVBoxLayout" name="verticalLayout">
-    <property name="margin">
+    <property name="leftMargin">
+     <number>0</number>
+    </property>
+    <property name="topMargin">
+     <number>0</number>
+    </property>
+    <property name="rightMargin">
+     <number>0</number>
+    </property>
+    <property name="bottomMargin">
      <number>0</number>
     </property>
     <item>
@@ -34,8 +43,8 @@
         <rect>
          <x>0</x>
          <y>0</y>
-         <width>388</width>
-         <height>304</height>
+         <width>398</width>
+         <height>314</height>
         </rect>
        </property>
        <layout class="QGridLayout" name="gridLayout">
@@ -57,7 +66,7 @@
            <bool>false</bool>
           </property>
           <property name="readOnly">
-           <bool>true</bool>
+           <bool>false</bool>
           </property>
          </widget>
         </item>


### PR DESCRIPTION
When opening the profile editor, the description field is populated but
is marked `readOnly` for some reason; all the back-end code existed to
make this read-write (except in the case when the profile lacks a
description, see the comment in [`TailoringWindow::setProfileDescription`](https://github.com/OpenSCAP/scap-workbench/blob/v1-2/src/TailoringWindow.cpp#L529)
and [`TailoringWindow::setProfileTitle`](https://github.com/OpenSCAP/scap-workbench/blob/v1-2/src/TailoringWindow.cpp#L491)).

This makes the field read-write.

Note that the behavior is less than ideal: `<xccdf:description />` can
include HTML content, and while this is a HTML-aware editor, hitting the
return key inserts merely a '`\n`' into the text stream and not a `<br />`
(or better, `<xhtml:br />` with XML-NS awareness) element.

Perhaps this behavior should be corrected at the openscap library level,
detecting the HTML XML namespace applied on the `<xccdf:description />`
element and namespacing the input correctly?

`Signed-off-by: Alexander Scheel <alex.scheel@canonical.com>`

---

n.b.: I used qtcreator to modify the UI, let me know if you want me to go back and undo the other changes to the UI file and only modify the boolean. 