### PR TITLE
Fix remote scanning with sudo

### DIFF
--- a/include/OscapScannerRemoteSsh.h
+++ b/include/OscapScannerRemoteSsh.h
@@ -55,12 +55,12 @@ class OscapScannerRemoteSsh : public OscapScannerBase
         QString copyFileOver(const QString& localPath);
         QString copyInputFileOver();
 
-        QString createRemoteTemporaryFile(bool cancelOnFailure = true);
+        QString createRemoteTemporaryFile(bool cancelOnFailure = true, bool with_sudo = false);
         QString createRemoteTemporaryDirectory(bool cancelOnFailure = true);
 
-        QString readRemoteFile(const QString& path, const QString& desc);
+        QString readRemoteFile(const QString& path, const QString& desc, bool with_sudo = false);
 
-        void removeRemoteFile(const QString& path, const QString& desc);
+        void removeRemoteFile(const QString& path, const QString& desc, bool with_sudo = false);
         void removeRemoteDirectory(const QString& path, const QString& desc);
 
         SshConnection mSshConnection;


### PR DESCRIPTION
This fix ensures that various temp files that are created and used in the process have the same owner all the time - if the scan is executed with sudo, then the owner of report, ARF and result files has to be root from the beginning to the end.

The root user in RHEL9 can't just write to files owned by other users.

This PR fixes https://bugzilla.redhat.com/show_bug.cgi?id=2047740